### PR TITLE
Fix accessory stacking and offhand buffs

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/DatabaseManager.java
+++ b/src/main/java/com/maks/trinketsplugin/DatabaseManager.java
@@ -187,6 +187,11 @@ public class DatabaseManager {
                 return;
             }
 
+            if (item.getAmount() > 1) {
+                player.sendMessage(ChatColor.RED + "Accessories must be unstacked before equipping.");
+                return;
+            }
+
             int minLevelForOtherSlots = 50;
             int playerLevel = player.getLevel();
 
@@ -260,6 +265,7 @@ public class DatabaseManager {
             ItemStack accessoryToReturn = item.clone();
             accessoryToReturn.setAmount(1);
             player.getInventory().addItem(accessoryToReturn);
+            TrinketsPlugin.getInstance().getOffhandListener().updateOffhand(player);
 
             player.sendMessage("You have unequipped the " + type.getDisplayName() + ".");
             sendBlockStatsInfo(player, data, item, false);

--- a/src/main/java/com/maks/trinketsplugin/InventoryClickListener.java
+++ b/src/main/java/com/maks/trinketsplugin/InventoryClickListener.java
@@ -37,6 +37,11 @@ public class InventoryClickListener implements Listener {
             }
 
         } else if (title.equals("Accessories")) {
+            // Allow players to interact with their own inventory without triggering unequip logic
+            if (event.getClickedInventory() == null || event.getClickedInventory().equals(player.getInventory())) {
+                return;
+            }
+
             event.setCancelled(true);
 
             ItemStack clickedItem = event.getCurrentItem();

--- a/src/main/java/com/maks/trinketsplugin/OffhandListener.java
+++ b/src/main/java/com/maks/trinketsplugin/OffhandListener.java
@@ -1,0 +1,104 @@
+package com.maks.trinketsplugin;
+
+import com.google.common.collect.Multimap;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+public class OffhandListener implements Listener {
+    private final TrinketsPlugin plugin;
+
+    public OffhandListener(TrinketsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onSwap(PlayerSwapHandItemsEvent event) {
+        Bukkit.getScheduler().runTask(plugin, () -> updateOffhand(event.getPlayer()));
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        if (event.getSlotType() != InventoryType.SlotType.QUICKBAR
+                || event.getSlot() != PlayerInventory.SLOT_OFFHAND) return;
+        Player player = (Player) event.getWhoClicked();
+        Bukkit.getScheduler().runTask(plugin, () -> updateOffhand(player));
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        Bukkit.getScheduler().runTask(plugin, () -> updateOffhand(event.getPlayer()));
+    }
+
+    public void updateOffhand(Player player) {
+        removeOffhandModifiers(player);
+
+        ItemStack item = player.getInventory().getItemInOffHand();
+        if (item == null || item.getType() == Material.AIR) return;
+        if (!isAccessoryItem(item)) return;
+
+        applyNegativeAttributes(player, item);
+    }
+
+    private boolean isAccessoryItem(ItemStack item) {
+        for (RestrictedAccessory accessory : plugin.getDatabaseManager().getRestrictedAccessories()) {
+            if (accessory.matches(item)) {
+                return true;
+            }
+        }
+        for (AccessoryType type : AccessoryType.values()) {
+            if (type.getMaterial() == item.getType()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void applyNegativeAttributes(Player player, ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        Multimap<Attribute, AttributeModifier> modifiers = meta.getAttributeModifiers();
+        if (modifiers == null) return;
+        for (Attribute attribute : modifiers.keySet()) {
+            AttributeInstance instance = player.getAttribute(attribute);
+            if (instance == null) continue;
+            for (AttributeModifier modifier : modifiers.get(attribute)) {
+                AttributeModifier negative = new AttributeModifier(
+                        UUID.randomUUID(),
+                        "trinket.offhand." + modifier.getName(),
+                        -modifier.getAmount(),
+                        modifier.getOperation(),
+                        modifier.getSlot());
+                instance.addModifier(negative);
+            }
+        }
+    }
+
+    private void removeOffhandModifiers(Player player) {
+        for (Attribute attribute : Attribute.values()) {
+            AttributeInstance instance = player.getAttribute(attribute);
+            if (instance == null) continue;
+            for (AttributeModifier modifier : new ArrayList<>(instance.getModifiers())) {
+                if (modifier.getName().startsWith("trinket.offhand.")) {
+                    instance.removeModifier(modifier);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/PlayerInteractListener.java
+++ b/src/main/java/com/maks/trinketsplugin/PlayerInteractListener.java
@@ -24,6 +24,7 @@ public class PlayerInteractListener implements Listener {
             if (isAccessoryItem(item)) {
                 // Equip the accessory
                 TrinketsPlugin.getInstance().getDatabaseManager().equipAccessory(player, item);
+                TrinketsPlugin.getInstance().getOffhandListener().updateOffhand(player);
                 event.setCancelled(true);
             } else if (isJewelItem(item)) {
                 // Equip the jewel

--- a/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
+++ b/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
@@ -16,6 +16,7 @@ public class TrinketsPlugin extends JavaPlugin {
     private File blokadyFile;
     private FileConfiguration blokadyConfig;
     private JewelManager jewelManager;
+    private OffhandListener offhandListener;
     private static final int debuggingFlag = 1;
 
     private static Economy econ = null;
@@ -68,6 +69,8 @@ public class TrinketsPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlayerInteractListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerDamageListener(), this); // Register the new listener
+        offhandListener = new OffhandListener(this);
+        getServer().getPluginManager().registerEvents(offhandListener, this);
         getServer().getPluginManager().registerEvents(new JewelEvents(this, jewelManager), this);
         getServer().getPluginManager().registerEvents(new Q1SoulEffect(this), this);
         getServer().getPluginManager().registerEvents(new Q2SoulEffect(this), this);
@@ -122,6 +125,10 @@ public class TrinketsPlugin extends JavaPlugin {
 
     public JewelManager getJewelManager() {
         return jewelManager;
+    }
+
+    public OffhandListener getOffhandListener() {
+        return offhandListener;
     }
     private boolean setupEconomy() {
         if (getServer().getPluginManager().getPlugin("Vault") == null) {


### PR DESCRIPTION
## Summary
- prevent stacked accessories from equipping
- stop accessory menu clicks from duplicating items
- neutralize accessory attribute buffs when held in the off-hand
- fix off-hand slot detection using PlayerInventory.SLOT_OFFHAND

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688dcd34cbc8832a9bdea3b9aca28770