### PR TITLE
Prevent trinkets granting stats in main hand

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/OffhandListener.java
+++ b/src/main/java/com/maks/trinketsplugin/OffhandListener.java
@@ -11,10 +11,10 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
 
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -31,32 +31,57 @@ public class OffhandListener implements Listener {
 
     @EventHandler
     public void onSwap(PlayerSwapHandItemsEvent event) {
-        Bukkit.getScheduler().runTask(plugin, () -> updateOffhand(event.getPlayer()));
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            updateOffhand(event.getPlayer());
+            updateMainHand(event.getPlayer());
+        });
     }
 
     @EventHandler
     public void onClick(InventoryClickEvent event) {
         if (!(event.getWhoClicked() instanceof Player)) return;
-        if (event.getSlotType() != InventoryType.SlotType.QUICKBAR
-                || event.getSlot() != 40) return;
-
         Player player = (Player) event.getWhoClicked();
-        Bukkit.getScheduler().runTask(plugin, () -> updateOffhand(player));
+
+        if (event.getSlotType() != InventoryType.SlotType.QUICKBAR) return;
+
+        if (event.getSlot() == 40) {
+            Bukkit.getScheduler().runTask(plugin, () -> updateOffhand(player));
+        } else if (event.getSlot() == player.getInventory().getHeldItemSlot()) {
+            Bukkit.getScheduler().runTask(plugin, () -> updateMainHand(player));
+        }
     }
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
-        Bukkit.getScheduler().runTask(plugin, () -> updateOffhand(event.getPlayer()));
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            updateOffhand(event.getPlayer());
+            updateMainHand(event.getPlayer());
+        });
+    }
+
+    @EventHandler
+    public void onItemHeld(PlayerItemHeldEvent event) {
+        Bukkit.getScheduler().runTask(plugin, () -> updateMainHand(event.getPlayer()));
     }
 
     public void updateOffhand(Player player) {
-        removeOffhandModifiers(player);
+        removeModifiers(player, "trinket.offhand.");
 
         ItemStack item = player.getInventory().getItemInOffHand();
         if (item == null || item.getType() == Material.AIR) return;
         if (!isAccessoryItem(item)) return;
 
-        applyNegativeAttributes(player, item);
+        applyNegativeAttributes(player, item, "offhand");
+    }
+
+    public void updateMainHand(Player player) {
+        removeModifiers(player, "trinket.mainhand.");
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType() == Material.AIR) return;
+        if (!isAccessoryItem(item)) return;
+
+        applyNegativeAttributes(player, item, "mainhand");
     }
 
     private boolean isAccessoryItem(ItemStack item) {
@@ -73,7 +98,7 @@ public class OffhandListener implements Listener {
         return false;
     }
 
-    private void applyNegativeAttributes(Player player, ItemStack item) {
+    private void applyNegativeAttributes(Player player, ItemStack item, String source) {
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
         Multimap<Attribute, AttributeModifier> modifiers = meta.getAttributeModifiers();
@@ -88,7 +113,7 @@ public class OffhandListener implements Listener {
             for (AttributeModifier modifier : attributeModifiers) {
                 AttributeModifier negative = new AttributeModifier(
                         UUID.randomUUID(),
-                        "trinket.offhand." + modifier.getName(),
+                        "trinket." + source + "." + modifier.getName(),
                         -modifier.getAmount(),
                         modifier.getOperation(),
                         modifier.getSlot());
@@ -97,12 +122,12 @@ public class OffhandListener implements Listener {
         }
     }
 
-    private void removeOffhandModifiers(Player player) {
+    private void removeModifiers(Player player, String prefix) {
         for (Attribute attribute : Attribute.values()) {
             AttributeInstance instance = player.getAttribute(attribute);
             if (instance == null) continue;
             for (AttributeModifier modifier : new ArrayList<>(instance.getModifiers())) {
-                if (modifier.getName().startsWith("trinket.offhand.")) {
+                if (modifier.getName().startsWith(prefix)) {
                     instance.removeModifier(modifier);
                 }
             }

--- a/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
+++ b/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
@@ -91,6 +91,10 @@ public class TrinketsPlugin extends JavaPlugin {
 
                 // Apply jewel attributes
                 jewelManager.applyJewelAttributes(player, data);
+
+                // Ensure accessories in hands don't grant attributes
+                offhandListener.updateOffhand(player);
+                offhandListener.updateMainHand(player);
             });
         }
 


### PR DESCRIPTION
## Summary
- avoid trinket stat bonuses when held in the main hand by negating attributes
- update plugin initialization to strip bonuses from both hands for online players

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688dd55d111c832aa8ed4006d9b91da6