### PR TITLE
Add gem actions command and GUI for socketing gems

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/GemActionsCommand.java
+++ b/src/main/java/com/maks/trinketsplugin/GemActionsCommand.java
@@ -1,0 +1,24 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class GemActionsCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (!player.hasPermission("mycraftingplugin.use")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+        GemActionsGUI.openMainMenu(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/GemActionsGUI.java
+++ b/src/main/java/com/maks/trinketsplugin/GemActionsGUI.java
@@ -1,0 +1,63 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class GemActionsGUI {
+    public static final String TITLE_MAIN = ChatColor.DARK_PURPLE + "Gem Actions";
+    public static final String TITLE_INSERT = ChatColor.DARK_PURPLE + "Insert Gem";
+    public static final String TITLE_EXTRACT = ChatColor.DARK_PURPLE + "Extract Gem";
+
+    private static ItemStack createFiller() {
+        ItemStack glass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta meta = glass.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            glass.setItemMeta(meta);
+        }
+        return glass;
+    }
+
+    private static ItemStack createMenuItem(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    public static void openMainMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, TITLE_MAIN);
+        ItemStack filler = createFiller();
+        for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+        inv.setItem(11, createMenuItem(Material.EMERALD, ChatColor.GREEN + "Insert Gem"));
+        inv.setItem(15, createMenuItem(Material.REDSTONE, ChatColor.RED + "Extract Gem"));
+        player.openInventory(inv);
+    }
+
+    public static void openInsertMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, TITLE_INSERT);
+        ItemStack filler = createFiller();
+        for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+        inv.clear(11);
+        inv.clear(15);
+        inv.setItem(22, createMenuItem(Material.ANVIL, ChatColor.YELLOW + "Confirm"));
+        player.openInventory(inv);
+    }
+
+    public static void openExtractMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, TITLE_EXTRACT);
+        ItemStack filler = createFiller();
+        for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+        inv.clear(13);
+        inv.setItem(22, createMenuItem(Material.ANVIL, ChatColor.YELLOW + "Confirm (50,000,000$)"));
+        player.openInventory(inv);
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/GemActionsListener.java
+++ b/src/main/java/com/maks/trinketsplugin/GemActionsListener.java
@@ -1,0 +1,224 @@
+package com.maks.trinketsplugin;
+
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class GemActionsListener implements Listener {
+
+    private void normalizeRarityLine(List<String> lore) {
+        for (int i = 0; i < lore.size(); i++) {
+            String stripped = ChatColor.stripColor(lore.get(i));
+            if (stripped.startsWith("Rarity:")) {
+                String line = lore.get(i);
+                int resetIndex = line.indexOf(ChatColor.RESET.toString());
+                String suffix = resetIndex >= 0 ? line.substring(resetIndex + ChatColor.RESET.toString().length()) : line.substring(line.indexOf(":") + 1);
+                lore.set(i, ChatColor.WHITE.toString() + ChatColor.BOLD + "Rarity:" + ChatColor.RESET + suffix);
+                break;
+            }
+        }
+    }
+
+    private void giveItem(Player player, ItemStack item) {
+        if (item == null) return;
+        Map<Integer, ItemStack> left = player.getInventory().addItem(item);
+        for (ItemStack leftover : left.values()) {
+            player.getWorld().dropItem(player.getLocation(), leftover);
+        }
+    }
+
+    private boolean isWeapon(Material type) {
+        String name = type.name();
+        return name.endsWith("_SWORD") || name.endsWith("_AXE") || name.endsWith("_SHOVEL") || name.endsWith("_HOE");
+    }
+
+    private boolean isArmor(Material type) {
+        String name = type.name();
+        return name.endsWith("_HELMET") || name.endsWith("_CHESTPLATE") || name.endsWith("_LEGGINGS") || name.endsWith("_BOOTS");
+    }
+
+    private EquipmentSlot getArmorSlot(Material type) {
+        String name = type.name();
+        if (name.endsWith("_HELMET")) return EquipmentSlot.HEAD;
+        if (name.endsWith("_CHESTPLATE")) return EquipmentSlot.CHEST;
+        if (name.endsWith("_LEGGINGS")) return EquipmentSlot.LEGS;
+        if (name.endsWith("_BOOTS")) return EquipmentSlot.FEET;
+        return EquipmentSlot.CHEST;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        Player player = (Player) event.getWhoClicked();
+        Inventory top = event.getView().getTopInventory();
+        String title = event.getView().getTitle();
+
+        if (title.equals(GemActionsGUI.TITLE_MAIN)) {
+            event.setCancelled(true);
+            ItemStack clicked = event.getCurrentItem();
+            if (clicked == null) return;
+            if (clicked.getType() == Material.EMERALD) {
+                GemActionsGUI.openInsertMenu(player);
+            } else if (clicked.getType() == Material.REDSTONE) {
+                GemActionsGUI.openExtractMenu(player);
+            }
+        } else if (title.equals(GemActionsGUI.TITLE_INSERT)) {
+            if (event.getClickedInventory() == top) {
+                int slot = event.getSlot();
+                if (slot == 11 || slot == 15) {
+                    event.setCancelled(false);
+                } else if (slot == 22) {
+                    event.setCancelled(true);
+                    handleInsertConfirm(player, top);
+                } else {
+                    event.setCancelled(true);
+                }
+            }
+        } else if (title.equals(GemActionsGUI.TITLE_EXTRACT)) {
+            if (event.getClickedInventory() == top) {
+                int slot = event.getSlot();
+                if (slot == 13) {
+                    event.setCancelled(false);
+                } else if (slot == 22) {
+                    event.setCancelled(true);
+                    handleExtractConfirm(player, top);
+                } else {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+    private void handleInsertConfirm(Player player, Inventory inv) {
+        ItemStack item = inv.getItem(11);
+        ItemStack gemItem = inv.getItem(15);
+        if (item == null || gemItem == null) {
+            player.sendMessage(ChatColor.RED + "Place an item and a gem.");
+            return;
+        }
+        if (gemItem.getAmount() > 1) {
+            ItemStack leftover = gemItem.clone();
+            leftover.setAmount(gemItem.getAmount() - 1);
+            giveItem(player, leftover);
+            gemItem.setAmount(1);
+        }
+        GemType gem = GemType.fromItem(gemItem);
+        if (gem == null) {
+            player.sendMessage(ChatColor.RED + "Invalid gem.");
+            return;
+        }
+        boolean weapon = isWeapon(item.getType());
+        boolean armor = isArmor(item.getType());
+        if (!weapon && !armor) {
+            player.sendMessage(ChatColor.RED + "Item must be a weapon or armor.");
+            return;
+        }
+        ItemMeta meta = item.getItemMeta();
+        List<String> lore = meta != null && meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+        for (String line : lore) {
+            if (ChatColor.stripColor(line).contains("Socketed")) {
+                player.sendMessage(ChatColor.RED + "Item already has a gem.");
+                return;
+            }
+        }
+        String gemLore = gem.buildSocketLore(weapon);
+        int insertIndex = lore.size();
+        for (int i = 0; i < lore.size(); i++) {
+            if (ChatColor.stripColor(lore.get(i)).contains("Rarity:")) {
+                insertIndex = i;
+                break;
+            }
+        }
+        lore.add(insertIndex, gemLore);
+        normalizeRarityLine(lore);
+        if (meta != null) {
+            meta.setLore(lore);
+            EquipmentSlot slot = weapon ? EquipmentSlot.HAND : getArmorSlot(item.getType());
+            gem.applyAttributes(meta, weapon, slot);
+            item.setItemMeta(meta);
+        }
+        inv.setItem(11, null);
+        inv.setItem(15, null);
+        giveItem(player, item);
+        player.closeInventory();
+        player.sendMessage(ChatColor.GREEN + "Gem inserted!");
+    }
+
+    private void handleExtractConfirm(Player player, Inventory inv) {
+        ItemStack item = inv.getItem(13);
+        if (item == null) {
+            player.sendMessage(ChatColor.RED + "Place an item with a gem.");
+            return;
+        }
+        ItemMeta meta = item.getItemMeta();
+        List<String> lore = meta != null && meta.hasLore() ? new ArrayList<>(meta.getLore()) : null;
+        if (lore == null) {
+            player.sendMessage(ChatColor.RED + "This item has no gem.");
+            return;
+        }
+        GemType found = null;
+        String removeLine = null;
+        for (String line : lore) {
+            String stripped = ChatColor.stripColor(line);
+            if (!stripped.contains("Socketed")) continue;
+            for (GemType type : GemType.values()) {
+                if (stripped.startsWith(ChatColor.stripColor(type.getDisplay()))) {
+                    found = type;
+                    removeLine = line;
+                    break;
+                }
+            }
+            if (found != null) break;
+        }
+        if (found == null) {
+            player.sendMessage(ChatColor.RED + "This item has no gem.");
+            return;
+        }
+        Economy econ = TrinketsPlugin.getEconomy();
+        double cost = 50_000_000d;
+        if (econ.getBalance(player) < cost) {
+            player.sendMessage(ChatColor.RED + "You need $50,000,000 to extract a gem.");
+            return;
+        }
+        econ.withdrawPlayer(player, cost);
+        lore.remove(removeLine);
+        normalizeRarityLine(lore);
+        if (meta != null) {
+            meta.setLore(lore);
+            found.removeAttributes(meta);
+            item.setItemMeta(meta);
+        }
+        inv.setItem(13, null);
+        giveItem(player, item);
+        giveItem(player, found.createItem());
+        player.closeInventory();
+        player.sendMessage(ChatColor.GREEN + "Gem extracted!");
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player)) return;
+        Player player = (Player) event.getPlayer();
+        Inventory inv = event.getInventory();
+        String title = event.getView().getTitle();
+        if (title.equals(GemActionsGUI.TITLE_INSERT)) {
+            giveItem(player, inv.getItem(11));
+            giveItem(player, inv.getItem(15));
+        } else if (title.equals(GemActionsGUI.TITLE_EXTRACT)) {
+            giveItem(player, inv.getItem(13));
+        }
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/GemType.java
+++ b/src/main/java/com/maks/trinketsplugin/GemType.java
@@ -1,0 +1,245 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import com.google.common.collect.Multimap;
+
+import java.util.*;
+
+public enum GemType {
+    RUBY_I(Material.COOKED_MUTTON, "&9[ I ] Ruby", "&6⚔ Weapon Socket: &a+1% Damage", "&b🛡 Armor Socket: &a+20 Damage"),
+    RUBY_II(Material.COOKED_MUTTON, "&5[ II ] Ruby", "&6⚔ Weapon Socket: &a+2% Damage", "&b🛡 Armor Socket: &a+30 Damage"),
+    RUBY_III(Material.COOKED_MUTTON, "&6[ III ] Ruby", "&6⚔ Weapon Socket: &a+3% Damage", "&b🛡 Armor Socket: &a+40 Damage"),
+
+    AMETHYST_I(Material.COOKED_BEEF, "&9[ I ] Amethyst", "&6⚔ Weapon Socket: &a+1% Max Health", "&b🛡 Armor Socket: &a+5 Health"),
+    AMETHYST_II(Material.COOKED_BEEF, "&5[ II ] Amethyst", "&6⚔ Weapon Socket: &a+2% Max Health", "&b🛡 Armor Socket: &a+10 Health"),
+    AMETHYST_III(Material.COOKED_BEEF, "&6[ III ] Amethyst", "&6⚔ Weapon Socket: &a+3% Max Health", "&b🛡 Armor Socket: &a+15 Health"),
+
+    CYIANITE_I(Material.PORKCHOP, "&9[ I ] Cyianite", "&6⚔ Weapon Socket: &a+1% Damage Reduction", "&b🛡 Armor Socket: &a+2 Armor"),
+    CYIANITE_II(Material.PORKCHOP, "&5[ II ] Cyianite", "&6⚔ Weapon Socket: &a+2% Damage Reduction", "&b🛡 Armor Socket: &a+3 Armor"),
+    CYIANITE_III(Material.PORKCHOP, "&6[ III ] Cyianite", "&6⚔ Weapon Socket: &a+3% Damage Reduction", "&b🛡 Armor Socket: &a+4 Armor"),
+
+    ZIRCON_I(Material.COOKED_CHICKEN, "&9[ I ] Zircon", "&6⚔ Weapon Socket: &a+0.25 Attack Speed", "&b🛡 Armor Socket: &a+5% Attack Speed"),
+    ZIRCON_II(Material.COOKED_CHICKEN, "&5[ II ] Zircon", "&6⚔ Weapon Socket: &a+0.5 Attack Speed", "&b🛡 Armor Socket: &a+10% Attack Speed"),
+    ZIRCON_III(Material.COOKED_CHICKEN, "&6[ III ] Zircon", "&6⚔ Weapon Socket: &a+0.75 Attack Speed", "&b🛡 Armor Socket: &a+15% Attack Speed"),
+
+    DIAMOND_I(Material.RABBIT, "&9[ I ] Diamond", "&6⚔ Weapon Socket: &a+3% Armor Penetration", "&b🛡 Armor Socket: &a+1 Armor Penetration"),
+    DIAMOND_II(Material.RABBIT, "&5[ II ] Diamond", "&6⚔ Weapon Socket: &a+4% Armor Penetration", "&b🛡 Armor Socket: &a+2 Armor Penetration"),
+    DIAMOND_III(Material.RABBIT, "&6[ III ] Diamond", "&6⚔ Weapon Socket: &a+5% Armor Penetration", "&b🛡 Armor Socket: &a+3 Armor Penetration"),
+
+    RHODOLITE_I(Material.COOKED_RABBIT, "&9[ I ] Rhodolite", "&6⚔ Weapon Socket: &a+0.05 Move Speed", "&b🛡 Armor Socket: &a+1% Move Speed"),
+    RHODOLITE_II(Material.COOKED_RABBIT, "&5[ II ] Rhodolite", "&6⚔ Weapon Socket: &a+0.1 Move Speed", "&b🛡 Armor Socket: &a+2% Move Speed"),
+    RHODOLITE_III(Material.COOKED_RABBIT, "&6[ III ] Rhodolite", "&6⚔ Weapon Socket: &a+0.15 Move Speed", "&b🛡 Armor Socket: &a+3% Move Speed"),
+
+    ONYX_I(Material.COD, "&9[ I ] Onyx", "&6⚔ Weapon Socket: &a+1% Luck", "&b🛡 Armor Socket: &a+1 Luck"),
+    ONYX_II(Material.COD, "&5[ II ] Onyx", "&6⚔ Weapon Socket: &a+2% Luck", "&b🛡 Armor Socket: &a+2 Luck"),
+    ONYX_III(Material.COD, "&6[ III ] Onyx", "&6⚔ Weapon Socket: &a+3% Luck", "&b🛡 Armor Socket: &a+3 Luck");
+
+    private final Material material;
+    private final String display;
+    private final String weaponLore;
+    private final String armorLore;
+
+    GemType(Material material, String display, String weaponLore, String armorLore) {
+        this.material = material;
+        this.display = display;
+        this.weaponLore = weaponLore;
+        this.armorLore = armorLore;
+    }
+
+    public Material getMaterial() {
+        return material;
+    }
+
+    public String getDisplay() {
+        return ChatColor.translateAlternateColorCodes('&', display);
+    }
+
+    public String getWeaponLore() {
+        return ChatColor.translateAlternateColorCodes('&', weaponLore);
+    }
+
+    public String getArmorLore() {
+        return ChatColor.translateAlternateColorCodes('&', armorLore);
+    }
+
+    public ItemStack createItem() {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(getDisplay());
+            meta.setLore(Arrays.asList(getWeaponLore(), getArmorLore()));
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+            meta.setUnbreakable(true);
+            item.setItemMeta(meta);
+        }
+        item.addUnsafeEnchantment(Enchantment.DURABILITY, 10);
+        return item;
+    }
+
+    public String buildSocketLore(boolean weapon) {
+        String source = weapon ? weaponLore : armorLore;
+        String[] parts = source.split(":", 2);
+        String bonus = parts.length > 1 ? parts[1].trim() : source;
+        return ChatColor.translateAlternateColorCodes('&', display + " Socketed " + bonus) + ChatColor.RESET;
+    }
+
+    public void applyAttributes(ItemMeta meta, boolean weapon, EquipmentSlot slot) {
+        if (meta == null) return;
+        Attribute attribute;
+        double amount;
+        AttributeModifier.Operation op;
+        switch (this) {
+            case RUBY_I:
+                attribute = Attribute.GENERIC_ATTACK_DAMAGE;
+                amount = weapon ? 0.01 : 20;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case RUBY_II:
+                attribute = Attribute.GENERIC_ATTACK_DAMAGE;
+                amount = weapon ? 0.02 : 30;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case RUBY_III:
+                attribute = Attribute.GENERIC_ATTACK_DAMAGE;
+                amount = weapon ? 0.03 : 40;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+
+            case AMETHYST_I:
+                attribute = Attribute.GENERIC_MAX_HEALTH;
+                amount = weapon ? 0.01 : 5;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case AMETHYST_II:
+                attribute = Attribute.GENERIC_MAX_HEALTH;
+                amount = weapon ? 0.02 : 10;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case AMETHYST_III:
+                attribute = Attribute.GENERIC_MAX_HEALTH;
+                amount = weapon ? 0.03 : 15;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+
+            case CYIANITE_I:
+                attribute = Attribute.GENERIC_ARMOR;
+                amount = weapon ? 0.01 : 2;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case CYIANITE_II:
+                attribute = Attribute.GENERIC_ARMOR;
+                amount = weapon ? 0.02 : 3;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case CYIANITE_III:
+                attribute = Attribute.GENERIC_ARMOR;
+                amount = weapon ? 0.03 : 4;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+
+            case ZIRCON_I:
+                attribute = Attribute.GENERIC_ATTACK_SPEED;
+                amount = weapon ? 0.25 : 0.05;
+                op = weapon ? AttributeModifier.Operation.ADD_NUMBER : AttributeModifier.Operation.MULTIPLY_SCALAR_1;
+                break;
+            case ZIRCON_II:
+                attribute = Attribute.GENERIC_ATTACK_SPEED;
+                amount = weapon ? 0.5 : 0.10;
+                op = weapon ? AttributeModifier.Operation.ADD_NUMBER : AttributeModifier.Operation.MULTIPLY_SCALAR_1;
+                break;
+            case ZIRCON_III:
+                attribute = Attribute.GENERIC_ATTACK_SPEED;
+                amount = weapon ? 0.75 : 0.15;
+                op = weapon ? AttributeModifier.Operation.ADD_NUMBER : AttributeModifier.Operation.MULTIPLY_SCALAR_1;
+                break;
+
+            case DIAMOND_I:
+                attribute = Attribute.GENERIC_ATTACK_DAMAGE;
+                amount = weapon ? 0.03 : 1;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case DIAMOND_II:
+                attribute = Attribute.GENERIC_ATTACK_DAMAGE;
+                amount = weapon ? 0.04 : 2;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case DIAMOND_III:
+                attribute = Attribute.GENERIC_ATTACK_DAMAGE;
+                amount = weapon ? 0.05 : 3;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+
+            case RHODOLITE_I:
+                attribute = Attribute.GENERIC_MOVEMENT_SPEED;
+                amount = weapon ? 0.05 : 0.01;
+                op = weapon ? AttributeModifier.Operation.ADD_NUMBER : AttributeModifier.Operation.MULTIPLY_SCALAR_1;
+                break;
+            case RHODOLITE_II:
+                attribute = Attribute.GENERIC_MOVEMENT_SPEED;
+                amount = weapon ? 0.1 : 0.02;
+                op = weapon ? AttributeModifier.Operation.ADD_NUMBER : AttributeModifier.Operation.MULTIPLY_SCALAR_1;
+                break;
+            case RHODOLITE_III:
+                attribute = Attribute.GENERIC_MOVEMENT_SPEED;
+                amount = weapon ? 0.15 : 0.03;
+                op = weapon ? AttributeModifier.Operation.ADD_NUMBER : AttributeModifier.Operation.MULTIPLY_SCALAR_1;
+                break;
+
+            case ONYX_I:
+                attribute = Attribute.GENERIC_LUCK;
+                amount = weapon ? 0.01 : 1;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case ONYX_II:
+                attribute = Attribute.GENERIC_LUCK;
+                amount = weapon ? 0.02 : 2;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+            case ONYX_III:
+                attribute = Attribute.GENERIC_LUCK;
+                amount = weapon ? 0.03 : 3;
+                op = weapon ? AttributeModifier.Operation.MULTIPLY_SCALAR_1 : AttributeModifier.Operation.ADD_NUMBER;
+                break;
+
+            default:
+                return;
+        }
+        AttributeModifier modifier = new AttributeModifier(UUID.randomUUID(), "gem_" + name(), amount, op, slot);
+        meta.addAttributeModifier(attribute, modifier);
+    }
+
+    public void removeAttributes(ItemMeta meta) {
+        if (meta == null) return;
+        Multimap<Attribute, AttributeModifier> modifiers = meta.getAttributeModifiers();
+        if (modifiers == null) return;
+        for (Attribute attribute : new HashSet<>(modifiers.keySet())) {
+            for (AttributeModifier modifier : new ArrayList<>(modifiers.get(attribute))) {
+                if (modifier.getName().equals("gem_" + name())) {
+                    meta.removeAttributeModifier(attribute, modifier);
+                }
+            }
+        }
+    }
+
+    public static GemType fromItem(ItemStack item) {
+        if (item == null) return null;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) return null;
+        String name = ChatColor.stripColor(meta.getDisplayName());
+        for (GemType type : values()) {
+            if (ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', type.display)).equals(name)) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
+++ b/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
@@ -83,6 +83,7 @@ public class TrinketsPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new Q8SoulEffect(this), this);
         getServer().getPluginManager().registerEvents(new Q9SoulEffect(this), this);
         getServer().getPluginManager().registerEvents(new Q10SoulEffect(this), this);
+        getServer().getPluginManager().registerEvents(new GemActionsListener(), this);
         // Load data for already logged-in players
         for (Player player : Bukkit.getOnlinePlayers()) {
             getDatabaseManager().loadPlayerData(player.getUniqueId(), data -> {
@@ -105,6 +106,7 @@ public class TrinketsPlugin extends JavaPlugin {
         }
         getCommand("soul").setExecutor(new SoulCommand());
         getCommand("jewels").setExecutor(new JewelsCommand());
+        getCommand("gem_actions").setExecutor(new GemActionsCommand());
 
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -17,3 +17,8 @@ commands:
   jewels:
     description: "Show info about jewels"
     usage: /jewels
+  gem_actions:
+    description: Open gem actions GUI
+    usage: /gem_actions
+    permission: mycraftingplugin.use
+    permission-message: You do not have permission to use this command.


### PR DESCRIPTION
## Summary
- add GemType enum defining all socketable gems
- create GemActions GUI, command, and listener for inserting and extracting gems
- register gem_actions command and permission in plugin.yml and main plugin class
- fix gem socket lore resetting and apply attribute modifiers on socketed items
- prevent consuming stacked gems and standardize Rarity line formatting

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_689c2adc4224832aa3508f156a546af9