### PR TITLE
Add ingredient jewel for extra crafting drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The plugin features a powerful jewel system that allows players to enhance their
    - Andermant Jewel: Chance to duplicate Andermant (10/20/30%)
    - Sunspire Amber: Get additional Gilded Sunflowers (1/2/3)
    - DrakenMelon Jewel: Get additional drakenmelons (1/2/3)
+   - Ingredient Jewel: Get additional ingredients (1/2/3)
    - Collector Jewel: Executes low health enemies (2/3/5% threshold)
 
 #### Commands

--- a/src/main/java/com/maks/trinketsplugin/JewelEvents.java
+++ b/src/main/java/com/maks/trinketsplugin/JewelEvents.java
@@ -23,9 +23,12 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 
 public class JewelEvents implements Listener {
@@ -37,6 +40,65 @@ public class JewelEvents implements Listener {
 
     // Flag to control visual effects
     private static final boolean SHOW_VISUAL_EFFECTS = false; // Set to true if you want particles
+
+    // Keywords for items affected by the Ingredient Jewel
+    private static final Set<String> INGREDIENT_KEYWORDS = new HashSet<>(Arrays.asList(
+            "Broken Armor Piece",
+            "Tousled Priest Robe",
+            "Black Fur",
+            "Dragon Scale",
+            "Chain Fragment",
+            "Satyr`s Horn",
+            "Gorgon`s Poison",
+            "Dragon`s Gold",
+            "Protector`s Heart",
+            "Dead Bush",
+            "Demon Blood",
+            "Sticky Mucus",
+            "Soul of an Acient Spartan",
+            "Shadow Rose",
+            "Throphy of the Long Forgotten Bone Dragon",
+            "Monster Soul Fragment",
+            "Monster Heart Fragment",
+            "Grimmage Burned Cape",
+            "Arachna Poisonous Skeleton",
+            "Heredur's Glacial Armor",
+            "Bearach Honey Hide",
+            "Khalys Magic Robe",
+            "Herald's Dragon Skin",
+            "Sigrismarr's Eternal Ice",
+            "Medusa Stone Scales",
+            "Gorga's Broken Tooth",
+            "Mortis Sacrificial Bones",
+            "Ore",
+            "Cursed Blood",
+            "Shattered Bone",
+            "Leaf",
+            "Algal",
+            "Shiny Pearl",
+            "Heart of the Ocean",
+            "Hematite",
+            "Black Spinel",
+            "Black Diamond",
+            "Magnetite",
+            "Silver",
+            "Osmium",
+            "Azurite",
+            "Tanzanite",
+            "Blue Sapphire",
+            "Carnelian",
+            "Red Spinel",
+            "Pigeon Blood Ruby",
+            "Pyrite",
+            "Yellow Topaz",
+            "Yellow Sapphire",
+            "Malachite",
+            "Peridot",
+            "Tropiche Emerald",
+            "Danburite",
+            "Goshenite",
+            "Cerussite"
+    ));
 
     // Helper method to send action bar messages with cooldown
     private final Map<UUID, Long> lastActionBarTime = new HashMap<>();
@@ -448,7 +510,24 @@ public class JewelEvents implements Listener {
             // No action bar message for Lockpick Jewel
 
             if (debuggingFlag == 1) {
-                Bukkit.getLogger().info("[JewelEvents] Extra lockpicks given to player: " + 
+                Bukkit.getLogger().info("[JewelEvents] Extra lockpicks given to player: " +
+                        player.getName() + ", amount: " + extraAmount);
+            }
+        }
+
+        // Handle INGREDIENT jewel
+        ItemStack ingredientJewel = data.getJewel(JewelType.INGREDIENT);
+        if (ingredientJewel != null && itemName != null &&
+                INGREDIENT_KEYWORDS.stream().anyMatch(itemName::contains)) {
+            int tier = jewelManager.getJewelTier(ingredientJewel);
+            int extraAmount = tier == 1 ? 1 : tier == 2 ? 2 : 3;
+
+            ItemStack extraItem = item.clone();
+            extraItem.setAmount(extraAmount);
+            player.getInventory().addItem(extraItem);
+
+            if (debuggingFlag == 1) {
+                Bukkit.getLogger().info("[JewelEvents] Extra ingredients given to player: " +
                         player.getName() + ", amount: " + extraAmount);
             }
         }

--- a/src/main/java/com/maks/trinketsplugin/JewelManager.java
+++ b/src/main/java/com/maks/trinketsplugin/JewelManager.java
@@ -628,6 +628,13 @@ public class JewelManager {
                 lore.add(ChatColor.translateAlternateColorCodes('&', "&7A dark jewel that whispers secrets"));
                 lore.add(ChatColor.translateAlternateColorCodes('&', "&7of locks and teaches nimble fingers."));
                 break;
+            case INGREDIENT:
+                int extraIngredients = tier == 1 ? 1 : tier == 2 ? 2 : 3;
+                lore.add(ChatColor.translateAlternateColorCodes('&', "&6Get +" + extraIngredients + " additional Ingredients"));
+                lore.add(ChatColor.translateAlternateColorCodes('&', "&6when picked up"));
+                lore.add(ChatColor.translateAlternateColorCodes('&', "&7A forager gem, blessed by the Hut,"));
+                lore.add(ChatColor.translateAlternateColorCodes('&', "&7guides hands to the freshest finds."));
+                break;
             case COLLECTOR:
                 double executeThreshold = tier == 1 ? 2 : tier == 2 ? 3 : 5;
                 lore.add(ChatColor.translateAlternateColorCodes('&', "&6Enemies below " + executeThreshold + "% HP"));

--- a/src/main/java/com/maks/trinketsplugin/JewelType.java
+++ b/src/main/java/com/maks/trinketsplugin/JewelType.java
@@ -20,6 +20,7 @@ public enum JewelType {
     CLOVER("Sunspire Amber", Material.GLOWSTONE_DUST, "Get additional clovers", 3),
     DRAKENMELON("Melonbane Prism", Material.SUGAR, "Get additional drakenmelons", 3),
     LOCKPICK("Shadowpick Onyx", Material.FEATHER, "Get additional lockpicks", 3),
+    INGREDIENT("Ingredient Jewel", Material.PRISMARINE_SHARD, "Get additional ingredients", 3),
     COLLECTOR("Deathcut Garnet", Material.GHAST_TEAR, "Finishes off low health enemies", 3);
 
     private final String displayName;


### PR DESCRIPTION
## Summary
- add new Ingredient Jewel type and lore
- grant extra crafting ingredients when picking up supported items
- document Ingredient Jewel in README
- extend ingredient jewel to include mine category blocks

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*
- `mvn -q -e -o package` *(fails: artifact not previously downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_689c4aa2df78832aad3eaa40c7355ab4