### PR TITLE
Add basic rune inventory system

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/InventoryClickListener.java
+++ b/src/main/java/com/maks/trinketsplugin/InventoryClickListener.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
+import java.util.List;
 
 public class InventoryClickListener implements Listener {
 
@@ -29,7 +30,7 @@ public class InventoryClickListener implements Listener {
             if (itemName.equals("Accessories")) {
                 TrinketsGUI.openAccessoriesMenu(player);
             } else if (itemName.equals("Runes")) {
-                // Future implementation
+                RunesGUI.openRunesMenu(player);
             } else if (itemName.equals("Gems")) {
                 // Future implementation
             } else if (itemName.equals("Jewels")) {
@@ -119,6 +120,27 @@ public class InventoryClickListener implements Listener {
                 TrinketsPlugin.getInstance().getJewelManager().unequipJewel(player, type);
                 // Refresh the focus jewels menu
                 JewelsGUI.openFocusJewelsMenu(player);
+            }
+        } else if (title.equals("Runes")) {
+            event.setCancelled(true);
+
+            ItemStack clickedItem = event.getCurrentItem();
+            if (clickedItem == null || clickedItem.getType() == Material.AIR) return;
+
+            // If it's a locked or empty slot, do nothing
+            if (clickedItem.getType().toString().contains("GLASS_PANE") ||
+                clickedItem.getType() == Material.BARRIER) return;
+
+            int slot = event.getSlot();
+            PlayerData data = TrinketsPlugin.getInstance().getDatabaseManager().getPlayerData(player.getUniqueId());
+            List<ItemStack> runes = new java.util.ArrayList<>(data.getRunes());
+
+            if (slot < runes.size()) {
+                ItemStack rune = runes.remove(slot);
+                player.getInventory().addItem(rune);
+                data.removeRune(slot);
+                TrinketsPlugin.getInstance().getDatabaseManager().savePlayerData(player.getUniqueId(), data);
+                RunesGUI.openRunesMenu(player);
             }
         }
     }

--- a/src/main/java/com/maks/trinketsplugin/PlayerData.java
+++ b/src/main/java/com/maks/trinketsplugin/PlayerData.java
@@ -22,6 +22,9 @@ public class PlayerData {
     // Added field for jewels
     private EnumMap<JewelType, ItemStack> jewels = new EnumMap<>(JewelType.class);
 
+    // List of equipped runes (up to 9 slots)
+    private List<ItemStack> runes = new ArrayList<>();
+
     // Accumulated blockChance and blockStrength from all equipped accessories
     private int blockChance = 0;   // Total Block Chance (%)
     private int blockStrength = 0; // Total Block Strength (%)
@@ -71,6 +74,23 @@ public class PlayerData {
             }
         }
         return count;
+    }
+
+    // Methods for runes
+    public List<ItemStack> getRunes() {
+        return Collections.unmodifiableList(runes);
+    }
+
+    public void addRune(ItemStack item) {
+        if (runes.size() < 9) {
+            runes.add(item);
+        }
+    }
+
+    public void removeRune(int index) {
+        if (index >= 0 && index < runes.size()) {
+            runes.remove(index);
+        }
     }
 
     // Recalculate total blockChance and blockStrength from all equipped accessories
@@ -230,6 +250,17 @@ public class PlayerData {
             }
         }
 
+        // Serialize runes
+        for (int i = 0; i < runes.size(); i++) {
+            ItemStack rune = runes.get(i);
+            try {
+                String itemData = ItemSerializationUtils.itemStackToBase64(rune);
+                sb.append("RUNE_").append(i).append(":").append(itemData).append(";");
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
         // Serialize blockChance and blockStrength
         sb.append("blockChance=").append(blockChance).append(";");
         sb.append("blockStrength=").append(blockStrength).append(";");
@@ -272,6 +303,17 @@ public class PlayerData {
                     if (debuggingFlag == 1) {
                         System.out.println("[PlayerData] Deserialized jewel: " + jewelType);
                     }
+                } catch (IllegalArgumentException | IOException e) {
+                    e.printStackTrace();
+                }
+            } else if (entry.startsWith("RUNE_")) {
+                // Deserialize runes
+                String[] parts = entry.split(":", 2);
+                if (parts.length < 2) continue;
+
+                try {
+                    ItemStack item = ItemSerializationUtils.itemStackFromBase64(parts[1]);
+                    runes.add(item);
                 } catch (IllegalArgumentException | IOException e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/com/maks/trinketsplugin/PlayerInteractListener.java
+++ b/src/main/java/com/maks/trinketsplugin/PlayerInteractListener.java
@@ -30,6 +30,9 @@ public class PlayerInteractListener implements Listener {
                 // Equip the jewel
                 TrinketsPlugin.getInstance().getJewelManager().equipJewel(player, item);
                 event.setCancelled(true);
+            } else if (isRuneItem(item)) {
+                TrinketsPlugin.getInstance().getRuneManager().equipRune(player, item);
+                event.setCancelled(true);
             }
         }
     }
@@ -54,6 +57,10 @@ public class PlayerInteractListener implements Listener {
     private boolean isJewelItem(ItemStack item) {
         // Use JewelManager to check if the item is a jewel
         return TrinketsPlugin.getInstance().getJewelManager().isJewel(item);
+    }
+
+    private boolean isRuneItem(ItemStack item) {
+        return TrinketsPlugin.getInstance().getRuneManager().isRune(item);
     }
 
 

--- a/src/main/java/com/maks/trinketsplugin/RuneManager.java
+++ b/src/main/java/com/maks/trinketsplugin/RuneManager.java
@@ -1,0 +1,75 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+public class RuneManager {
+
+    private final TrinketsPlugin plugin;
+    private final List<String> runeNames = Arrays.asList(
+            "Uruz", "Algiz", "Shield", "Thurisaz", "Wunjo",
+            "Laguz", "Gebo", "Ehwaz", "Berkano"
+    );
+
+    public RuneManager(TrinketsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public boolean isRune(ItemStack item) {
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) {
+            return false;
+        }
+        String name = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+        return runeNames.stream().anyMatch(name::contains);
+    }
+
+    public void equipRune(Player player, ItemStack item) {
+        if (!isRune(item)) {
+            return;
+        }
+
+        UUID uuid = player.getUniqueId();
+        PlayerData data = plugin.getDatabaseManager().getPlayerData(uuid);
+        if (data == null) {
+            return;
+        }
+
+        int unlocked = getUnlockedSlots(player.getLevel());
+        if (data.getRunes().size() >= unlocked) {
+            player.sendMessage(ChatColor.RED + "No available rune slots.");
+            return;
+        }
+
+        ItemStack rune = item.clone();
+        rune.setAmount(1);
+        data.addRune(rune);
+        plugin.getDatabaseManager().savePlayerData(uuid, data);
+
+        if (player.getInventory().getItemInMainHand().equals(item)) {
+            ItemStack hand = player.getInventory().getItemInMainHand().clone();
+            hand.setAmount(hand.getAmount() - 1);
+            player.getInventory().setItemInMainHand(hand);
+        } else if (player.getInventory().getItemInOffHand().equals(item)) {
+            ItemStack off = player.getInventory().getItemInOffHand().clone();
+            off.setAmount(off.getAmount() - 1);
+            player.getInventory().setItemInOffHand(off);
+        } else {
+            item.setAmount(item.getAmount() - 1);
+        }
+
+        player.sendMessage(ChatColor.GREEN + "Rune equipped!");
+    }
+
+    private int getUnlockedSlots(int level) {
+        if (level < 50) {
+            return 0;
+        }
+        int slots = 1 + (level - 50) / 5;
+        return Math.min(slots, 9);
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/RunesGUI.java
+++ b/src/main/java/com/maks/trinketsplugin/RunesGUI.java
@@ -1,0 +1,66 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RunesGUI {
+
+    public static void openRunesMenu(Player player) {
+        Inventory gui = Bukkit.createInventory(null, 9, "Runes");
+
+        PlayerData data = TrinketsPlugin.getInstance().getDatabaseManager().getPlayerData(player.getUniqueId());
+        List<ItemStack> runes = data.getRunes();
+        int unlocked = getUnlockedSlots(player.getLevel());
+
+        for (int i = 0; i < 9; i++) {
+            if (i < unlocked) {
+                if (i < runes.size() && runes.get(i) != null) {
+                    ItemStack display = runes.get(i).clone();
+                    display.setAmount(1);
+                    gui.setItem(i, display);
+                } else {
+                    gui.setItem(i, createEmptySlot());
+                }
+            } else {
+                int reqLevel = 50 + i * 5;
+                gui.setItem(i, createLockedSlot(reqLevel));
+            }
+        }
+
+        player.openInventory(gui);
+    }
+
+    private static int getUnlockedSlots(int level) {
+        if (level < 50) {
+            return 0;
+        }
+        int slots = 1 + (level - 50) / 5;
+        return Math.min(slots, 9);
+    }
+
+    private static ItemStack createEmptySlot() {
+        ItemStack item = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(ChatColor.GRAY + "Empty Slot");
+        meta.setLore(Arrays.asList(ChatColor.YELLOW + "Right-click a rune item", ChatColor.YELLOW + "to equip it."));
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private static ItemStack createLockedSlot(int level) {
+        ItemStack item = new ItemStack(Material.BARRIER);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(ChatColor.RED + "Locked Slot");
+        meta.setLore(Arrays.asList(ChatColor.GRAY + "Unlock at level " + level));
+        item.setItemMeta(meta);
+        return item;
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
+++ b/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
@@ -16,6 +16,7 @@ public class TrinketsPlugin extends JavaPlugin {
     private File blokadyFile;
     private FileConfiguration blokadyConfig;
     private JewelManager jewelManager;
+    private RuneManager runeManager;
     private OffhandListener offhandListener;
     private static final int debuggingFlag = 1;
 
@@ -39,6 +40,12 @@ public class TrinketsPlugin extends JavaPlugin {
             saveResource("jewels.yml", false);
         }
 
+        // Create runes.yml if it doesn't exist
+        File runesFile = new File(getDataFolder(), "runes.yml");
+        if (!runesFile.exists()) {
+            saveResource("runes.yml", false);
+        }
+
         // Initialize DatabaseManager
         databaseManager = new DatabaseManager();
 
@@ -50,6 +57,7 @@ public class TrinketsPlugin extends JavaPlugin {
 
         // Initialize JewelManager
         jewelManager = new JewelManager(this);
+        runeManager = new RuneManager(this);
 
         // Initialize JewelAPI
         JewelAPI.initialize(this);
@@ -132,6 +140,10 @@ public class TrinketsPlugin extends JavaPlugin {
 
     public JewelManager getJewelManager() {
         return jewelManager;
+    }
+
+    public RuneManager getRuneManager() {
+        return runeManager;
     }
 
     public OffhandListener getOffhandListener() {

--- a/src/main/resources/runes.yml
+++ b/src/main/resources/runes.yml
@@ -1,0 +1,365 @@
+# Runes configuration
+# Defines available runes and their in-game item representations
+
+RUNE_URUZ_I:
+  Id: BLADE_POTTERY_SHERD
+  Display: '&9[ I ] &fᚢ Uruz'
+  Lore:
+    - '&7Increased damage: &a+1%&7.'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_URUZ_II:
+  Id: BLADE_POTTERY_SHERD
+  Display: '&5[ II ] &fᚢ Uruz'
+  Lore:
+    - '&7Increased damage: &a+2%&7.'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_URUZ_III:
+  Id: BLADE_POTTERY_SHERD
+  Display: '&6[ III ] &fᚢ Uruz'
+  Lore:
+    - '&7Increased damage: &a+3%&7.'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_ALGIZ_I:
+  Id: SHELTER_POTTERY_SHERD
+  Display: '&9[ I ] &fᛉ Algiz'
+  Lore:
+    - '&7After taking a hit: reduce damage taken by &a8&7 (flat) for &a3s&7.'
+    - '&7Cooldown: &a10s'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_ALGIZ_II:
+  Id: SHELTER_POTTERY_SHERD
+  Display: '&5[ II ] &fᛉ Algiz'
+  Lore:
+    - '&7After taking a hit: reduce damage taken by &a12&7 (flat) for &a3s&7.'
+    - '&7Cooldown: &a10s'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_ALGIZ_III:
+  Id: SHELTER_POTTERY_SHERD
+  Display: '&6[ III ] &fᛉ Algiz'
+  Lore:
+    - '&7After taking a hit: reduce damage taken by &a16&7 (flat) for &a3s&7.'
+    - '&7Cooldown: &a10s'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_SHIELD_I:
+  Id: HEART_POTTERY_SHERD
+  Display: '&9[ I ] &fᛜ Shield'
+  Lore:
+    - '&7Below &a30%&7 HP: gain a &a200&7 barrier for &a5s&7.'
+    - '&7Cooldown: &a45s'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_SHIELD_II:
+  Id: HEART_POTTERY_SHERD
+  Display: '&5[ II ] &fᛜ Shield'
+  Lore:
+    - '&7Below &a30%&7 HP: gain a &a280&7 barrier for &a5s&7.'
+    - '&7Cooldown: &a45s'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_SHIELD_III:
+  Id: HEART_POTTERY_SHERD
+  Display: '&6[ III ] &fᛜ Shield'
+  Lore:
+    - '&7Below &a30%&7 HP: gain a &a360&7 barrier for &a5s&7.'
+    - '&7Cooldown: &a45s'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_THURISAZ_I:
+  Id: SKULL_POTTERY_SHERD
+  Display: '&9[ I ] &fᚦ Thurisaz'
+  Lore:
+    - '&7Reflects &a2%&7 of damage taken back to the attacker.'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_THURISAZ_II:
+  Id: SKULL_POTTERY_SHERD
+  Display: '&5[ II ] &fᚦ Thurisaz'
+  Lore:
+    - '&7Reflects &a3%&7 of damage taken back to the attacker.'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_THURISAZ_III:
+  Id: SKULL_POTTERY_SHERD
+  Display: '&6[ III ] &fᚦ Thurisaz'
+  Lore:
+    - '&7Reflects &a4%&7 of damage taken back to the attacker.'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_WUNJO_I:
+  Id: PRIZE_POTTERY_SHERD
+  Display: '&9[ I ] &fᚹ Wunjo'
+  Lore:
+    - '&7Luck: &a+1&7.'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_WUNJO_II:
+  Id: PRIZE_POTTERY_SHERD
+  Display: '&5[ II ] &fᚹ Wunjo'
+  Lore:
+    - '&7Luck: &a+2&7.'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_WUNJO_III:
+  Id: PRIZE_POTTERY_SHERD
+  Display: '&6[ III ] &fᚹ Wunjo'
+  Lore:
+    - '&7Luck: &a+3&7.'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_LAGUZ_I:
+  Id: ANGLER_POTTERY_SHERD
+  Display: '&9[ I ] &fᛚ Laguz'
+  Lore:
+    - '&7Heals for &a0.3%&7 of damage dealt (internal cooldown &a0.5s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_LAGUZ_II:
+  Id: ANGLER_POTTERY_SHERD
+  Display: '&5[ II ] &fᛚ Laguz'
+  Lore:
+    - '&7Heals for &a0.6%&7 of damage dealt (internal cooldown &a0.5s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_LAGUZ_III:
+  Id: ANGLER_POTTERY_SHERD
+  Display: '&6[ III ] &fᛚ Laguz'
+  Lore:
+    - '&7Heals for &a1.0%&7 of damage dealt (internal cooldown &a0.5s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_GEBO_I:
+  Id: PLENTY_POTTERY_SHERD
+  Display: '&9[ I ] &fᚷ Gebo'
+  Lore:
+    - '&7Overheal becomes a barrier of &a30&7 for &a5s&7 (CD &a15s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_GEBO_II:
+  Id: PLENTY_POTTERY_SHERD
+  Display: '&5[ II ] &fᚷ Gebo'
+  Lore:
+    - '&7Overheal becomes a barrier of &a60&7 for &a5s&7 (CD &a15s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_GEBO_III:
+  Id: PLENTY_POTTERY_SHERD
+  Display: '&6[ III ] &fᚷ Gebo'
+  Lore:
+    - '&7Overheal becomes a barrier of &a100&7 for &a5s&7 (CD &a15s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_EHWAZ_I:
+  Id: EXPLORER_POTTERY_SHERD
+  Display: '&9[ I ] &fᛖ Ehwaz'
+  Lore:
+    - '&7After &a2s&7 of sprinting: your next hit taken within &a3s&7 is reduced by &a20&7 (flat)'
+    - '&7and grants &a+20%&7 knockback resistance (CD &a8s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_EHWAZ_II:
+  Id: EXPLORER_POTTERY_SHERD
+  Display: '&5[ II ] &fᛖ Ehwaz'
+  Lore:
+    - '&7After &a2s&7 of sprinting: your next hit taken within &a3s&7 is reduced by &a35&7 (flat)'
+    - '&7and grants &a+30%&7 knockback resistance (CD &a8s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_EHWAZ_III:
+  Id: EXPLORER_POTTERY_SHERD
+  Display: '&6[ III ] &fᛖ Ehwaz'
+  Lore:
+    - '&7After &a2s&7 of sprinting: your next hit taken within &a3s&7 is reduced by &a50&7 (flat)'
+    - '&7and grants &a+40%&7 knockback resistance (CD &a8s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_BERKANO_I:
+  Id: SHEAF_POTTERY_SHERD
+  Display: '&9[ I ] &fᛒ Berkano'
+  Lore:
+    - '&7When dropping below &a30%&7 HP: cleanse &a1&7 negative effect and'
+    - '&7gain &a+20%&7 debuff resistance for &a3s&7 (CD &a25s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_BERKANO_II:
+  Id: SHEAF_POTTERY_SHERD
+  Display: '&5[ II ] &fᛒ Berkano'
+  Lore:
+    - '&7When dropping below &a30%&7 HP: cleanse &a1&7 negative effect and'
+    - '&7gain &a+30%&7 debuff resistance for &a3s&7 (CD &a25s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes
+
+RUNE_BERKANO_III:
+  Id: SHEAF_POTTERY_SHERD
+  Display: '&6[ III ] &fᛒ Berkano'
+  Lore:
+    - '&7When dropping below &a30%&7 HP: cleanse &a1&7 negative effect and'
+    - '&7gain &a+40%&7 debuff resistance for &a3s&7 (CD &a25s&7).'
+  Options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true
+  Enchantments:
+    - DURABILITY:10
+  Group: Runes


### PR DESCRIPTION
## Summary
- add rune manager and storage system with level-based slot unlocking
- provide runes GUI for viewing and removing equipped runes
- include initial runes configuration file

## Testing
- `mvn -q -e -DskipTests package` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f22f3b5cc832aba567ae3b81d8a95