### PR TITLE
Add Golden Fish Jewel for fishing rewards

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/JewelEvents.java
+++ b/src/main/java/com/maks/trinketsplugin/JewelEvents.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.Event;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -530,6 +531,44 @@ public class JewelEvents implements Listener {
                 Bukkit.getLogger().info("[JewelEvents] Extra ingredients given to player: " +
                         player.getName() + ", amount: " + extraAmount);
             }
+        }
+    }
+
+    @EventHandler
+    public void onFishReward(Event event) {
+        if (!event.getClass().getName().equals("org.maks.fishingPlugin.api.FishRewardEvent")) {
+            return;
+        }
+        try {
+            Player player = (Player) event.getClass().getMethod("getPlayer").invoke(event);
+            Object itemObj = event.getClass().getMethod("getItem").invoke(event);
+            if (!(itemObj instanceof ItemStack)) {
+                return;
+            }
+            ItemStack item = (ItemStack) itemObj;
+            if (item == null) {
+                return;
+            }
+
+            PlayerData data = plugin.getDatabaseManager().getPlayerData(player.getUniqueId());
+            if (data == null) {
+                return;
+            }
+
+            ItemStack fishJewel = data.getJewel(JewelType.GOLDEN_FISH);
+            if (fishJewel == null) {
+                return;
+            }
+
+            int tier = jewelManager.getJewelTier(fishJewel);
+            int chance = tier == 1 ? 30 : tier == 2 ? 40 : 50;
+
+            if (random.nextInt(100) < chance) {
+                ItemStack duplicate = item.clone();
+                player.getInventory().addItem(duplicate);
+                sendActionBar(player, ChatColor.GREEN + "Your Golden Fish Jewel doubled the catch!");
+            }
+        } catch (Exception ignored) {
         }
     }
 

--- a/src/main/java/com/maks/trinketsplugin/JewelManager.java
+++ b/src/main/java/com/maks/trinketsplugin/JewelManager.java
@@ -642,6 +642,13 @@ public class JewelManager {
                 lore.add(ChatColor.translateAlternateColorCodes('&', "&7A crystallized tear that hungers for"));
                 lore.add(ChatColor.translateAlternateColorCodes('&', "&7the souls of the nearly dead."));
                 break;
+            case GOLDEN_FISH:
+                int fishChance = tier == 1 ? 30 : tier == 2 ? 40 : 50;
+                lore.add(ChatColor.translateAlternateColorCodes('&', "&6Have a " + fishChance + "% chance"));
+                lore.add(ChatColor.translateAlternateColorCodes('&', "&6to double the caught item at Fishing Pool"));
+                lore.add(ChatColor.translateAlternateColorCodes('&', "&7A charm gilded by the tides,"));
+                lore.add(ChatColor.translateAlternateColorCodes('&', "&7blessing lucky hauls from the deep."));
+                break;
         }
 
         lore.add("");

--- a/src/main/java/com/maks/trinketsplugin/JewelType.java
+++ b/src/main/java/com/maks/trinketsplugin/JewelType.java
@@ -21,7 +21,8 @@ public enum JewelType {
     DRAKENMELON("Melonbane Prism", Material.SUGAR, "Get additional drakenmelons", 3),
     LOCKPICK("Shadowpick Onyx", Material.FEATHER, "Get additional lockpicks", 3),
     INGREDIENT("Ingredient Jewel", Material.PRISMARINE_SHARD, "Get additional ingredients", 3),
-    COLLECTOR("Deathcut Garnet", Material.GHAST_TEAR, "Finishes off low health enemies", 3);
+    COLLECTOR("Deathcut Garnet", Material.GHAST_TEAR, "Finishes off low health enemies", 3),
+    GOLDEN_FISH("Golden Fish Jewel", Material.WHEAT, "Chance to double fishing loot", 3);
 
     private final String displayName;
     private final Material material;

--- a/src/main/resources/jewels.yml
+++ b/src/main/resources/jewels.yml
@@ -244,3 +244,17 @@ jewels:
         execute_threshold_percent: 3
       tier3:
         execute_threshold_percent: 5
+
+  GOLDEN_FISH:
+    display_name: "Golden Fish Jewel"
+    material: WHEAT
+    description: "Chance to double the caught item at Fishing Pool"
+    max_tier: 3
+    max_equipped: 1
+    effects:
+      tier1:
+        double_chance_percent: 30
+      tier2:
+        double_chance_percent: 40
+      tier3:
+        double_chance_percent: 50


### PR DESCRIPTION
## Summary
- add `GOLDEN_FISH` jewel type that doubles fishing rewards
- handle `FishRewardEvent` to apply jewel bonus
- document jewel in `jewels.yml`

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a033de3a5c832a8f5eed893161b448