### PR TITLE
Add runic word conjuration system

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/ConjurationCommand.java
+++ b/src/main/java/com/maks/trinketsplugin/ConjurationCommand.java
@@ -1,0 +1,24 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class ConjurationCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (!player.hasPermission("mycraftingplugin.use")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+        ConjurationGUI.openMainMenu(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/ConjurationGUI.java
+++ b/src/main/java/com/maks/trinketsplugin/ConjurationGUI.java
@@ -1,0 +1,63 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class ConjurationGUI {
+    public static final String TITLE_MAIN = ChatColor.DARK_PURPLE + "Conjuration";
+    public static final String TITLE_ITEMS = ChatColor.DARK_PURPLE + "Items Conjuration";
+    public static final String TITLE_DISPEL = ChatColor.DARK_PURPLE + "Rune Words Dispel";
+
+    private static ItemStack createFiller() {
+        ItemStack glass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta meta = glass.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            glass.setItemMeta(meta);
+        }
+        return glass;
+    }
+
+    private static ItemStack createMenuItem(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    public static void openMainMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, TITLE_MAIN);
+        ItemStack filler = createFiller();
+        for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+        inv.setItem(11, createMenuItem(Material.DIAMOND_SWORD, ChatColor.GREEN + "Items Conjuration"));
+        inv.setItem(15, createMenuItem(Material.PAPER, ChatColor.YELLOW + "Rune Words Dispel"));
+        player.openInventory(inv);
+    }
+
+    public static void openItemsMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, TITLE_ITEMS);
+        ItemStack filler = createFiller();
+        for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+        inv.clear(11);
+        inv.clear(15);
+        inv.setItem(22, createMenuItem(Material.ANVIL, ChatColor.YELLOW + "Conjure (100,000,000$)"));
+        player.openInventory(inv);
+    }
+
+    public static void openDispelMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, TITLE_DISPEL);
+        ItemStack filler = createFiller();
+        for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+        inv.clear(13);
+        inv.setItem(22, createMenuItem(Material.ANVIL, ChatColor.YELLOW + "Dispel (250,000,000$)"));
+        player.openInventory(inv);
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/ConjurationListener.java
+++ b/src/main/java/com/maks/trinketsplugin/ConjurationListener.java
@@ -1,0 +1,143 @@
+package com.maks.trinketsplugin;
+
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Map;
+
+public class ConjurationListener implements Listener {
+
+    private boolean isWeapon(Material type) {
+        String name = type.name();
+        return name.endsWith("_SWORD") || name.endsWith("_AXE") || name.endsWith("_SHOVEL") || name.endsWith("_HOE");
+    }
+
+    private void giveItem(Player player, ItemStack item) {
+        if (item == null) return;
+        Map<Integer, ItemStack> leftover = player.getInventory().addItem(item);
+        for (ItemStack left : leftover.values()) {
+            player.getWorld().dropItem(player.getLocation(), left);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        Player player = (Player) event.getWhoClicked();
+        Inventory top = event.getView().getTopInventory();
+        String title = event.getView().getTitle();
+
+        if (title.equals(ConjurationGUI.TITLE_MAIN)) {
+            event.setCancelled(true);
+            ItemStack clicked = event.getCurrentItem();
+            if (clicked == null) return;
+            if (clicked.getType() == Material.DIAMOND_SWORD) {
+                ConjurationGUI.openItemsMenu(player);
+            } else if (clicked.getType() == Material.PAPER) {
+                ConjurationGUI.openDispelMenu(player);
+            }
+        } else if (title.equals(ConjurationGUI.TITLE_ITEMS)) {
+            if (event.getClickedInventory() == top) {
+                int slot = event.getSlot();
+                if (slot == 11 || slot == 15) {
+                    event.setCancelled(false);
+                } else if (slot == 22) {
+                    event.setCancelled(true);
+                    handleConjure(player, top);
+                } else {
+                    event.setCancelled(true);
+                }
+            }
+        } else if (title.equals(ConjurationGUI.TITLE_DISPEL)) {
+            if (event.getClickedInventory() == top) {
+                int slot = event.getSlot();
+                if (slot == 13) {
+                    event.setCancelled(false);
+                } else if (slot == 22) {
+                    event.setCancelled(true);
+                    handleDispel(player, top);
+                } else {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+    private void handleConjure(Player player, Inventory inv) {
+        ItemStack weapon = inv.getItem(11);
+        ItemStack wordItem = inv.getItem(15);
+        if (weapon == null || wordItem == null) {
+            player.sendMessage(ChatColor.RED + "Place a weapon and a runic word.");
+            return;
+        }
+        if (!isWeapon(weapon.getType())) {
+            player.sendMessage(ChatColor.RED + "Item must be a weapon.");
+            return;
+        }
+        RunicWord word = RunicWord.fromItem(wordItem);
+        if (word == null) {
+            player.sendMessage(ChatColor.RED + "Invalid runic word.");
+            return;
+        }
+        Economy econ = TrinketsPlugin.getEconomy();
+        double cost = 100_000_000d;
+        if (econ.getBalance(player) < cost) {
+            player.sendMessage(ChatColor.RED + "You need $100,000,000 to conjure." );
+            return;
+        }
+        econ.withdrawPlayer(player, cost);
+        RunicWordManager.applyRunicWord(weapon, word);
+        inv.setItem(11, null);
+        inv.setItem(15, null);
+        giveItem(player, weapon);
+        player.closeInventory();
+        player.sendMessage(ChatColor.GREEN + "Weapon enchanted with " + word.getDisplayName() + "!");
+    }
+
+    private void handleDispel(Player player, Inventory inv) {
+        ItemStack weapon = inv.getItem(13);
+        if (weapon == null) {
+            player.sendMessage(ChatColor.RED + "Place a weapon.");
+            return;
+        }
+        RunicWord word = RunicWordManager.getRunicWord(weapon);
+        if (word == null) {
+            player.sendMessage(ChatColor.RED + "This weapon has no runic word.");
+            return;
+        }
+        Economy econ = TrinketsPlugin.getEconomy();
+        double cost = 250_000_000d;
+        if (econ.getBalance(player) < cost) {
+            player.sendMessage(ChatColor.RED + "You need $250,000,000 to dispel." );
+            return;
+        }
+        econ.withdrawPlayer(player, cost);
+        RunicWordManager.removeRunicWord(weapon);
+        inv.setItem(13, null);
+        giveItem(player, weapon);
+        player.closeInventory();
+        player.sendMessage(ChatColor.GREEN + "Runic word removed.");
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player)) return;
+        Player player = (Player) event.getPlayer();
+        Inventory inv = event.getInventory();
+        String title = event.getView().getTitle();
+        if (title.equals(ConjurationGUI.TITLE_ITEMS)) {
+            giveItem(player, inv.getItem(11));
+            giveItem(player, inv.getItem(15));
+        } else if (title.equals(ConjurationGUI.TITLE_DISPEL)) {
+            giveItem(player, inv.getItem(13));
+        }
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/RunicWord.java
+++ b/src/main/java/com/maks/trinketsplugin/RunicWord.java
@@ -1,0 +1,54 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Represents the different runic words that can be applied to weapons.
+ */
+public enum RunicWord {
+    RUNIC_TETHER("Runic Tether", 20),
+    SURGICAL_SEVER("Surgical Sever", 0),
+    BLESSING_THEFT("Blessing Theft", 22),
+    HUNTERS_MARK("Hunter's Mark", 20),
+    RHYTHMIC_DISPLACEMENT("Rhythmic Displacement", 28),
+    CROSSHAIR_RATTLE("Crosshair Rattle", 12),
+    WHIPLASH_SPRINT("Whiplash Sprint", 14),
+    MISCHIEF("Mischief", 16),
+    OVEREXTENSION("Overextension", 16);
+
+    private final String displayName;
+    private final int cooldown; // cooldown in seconds
+
+    RunicWord(String displayName, int cooldown) {
+        this.displayName = displayName;
+        this.cooldown = cooldown;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public int getCooldown() {
+        return cooldown;
+    }
+
+    /**
+     * Attempts to match an ItemStack to a runic word based on its display name.
+     *
+     * @param item item to inspect
+     * @return matching RunicWord or null if the item is not a runic word
+     */
+    public static RunicWord fromItem(ItemStack item) {
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) {
+            return null;
+        }
+        String stripped = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+        for (RunicWord word : values()) {
+            if (stripped.contains(word.displayName)) {
+                return word;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/RunicWordEffectsListener.java
+++ b/src/main/java/com/maks/trinketsplugin/RunicWordEffectsListener.java
@@ -1,0 +1,268 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import java.util.*;
+
+/**
+ * Handles combat effects for weapons imbued with runic words.
+ */
+public class RunicWordEffectsListener implements Listener {
+
+    private final TrinketsPlugin plugin;
+
+    public RunicWordEffectsListener(TrinketsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    private final Map<String, Integer> tetherHits = new HashMap<>();
+    private final Map<UUID, Long> tetherCooldown = new HashMap<>();
+
+    private final Map<UUID, Long> surgicalSever = new HashMap<>();
+
+    private final Map<UUID, Long> blessingCooldown = new HashMap<>();
+    private static final Set<PotionEffectType> POSITIVE_EFFECTS = Set.of(
+            PotionEffectType.ABSORPTION, PotionEffectType.DAMAGE_RESISTANCE, PotionEffectType.FAST_DIGGING,
+            PotionEffectType.FIRE_RESISTANCE, PotionEffectType.GLOWING, PotionEffectType.HEALTH_BOOST,
+            PotionEffectType.INCREASE_DAMAGE, PotionEffectType.INVISIBILITY, PotionEffectType.JUMP,
+            PotionEffectType.NIGHT_VISION, PotionEffectType.REGENERATION, PotionEffectType.SPEED
+    );
+
+    private final Map<String, Integer> huntersHits = new HashMap<>();
+    private final Map<String, Long> huntersFirstHit = new HashMap<>();
+    private final Map<UUID, Long> huntersCooldown = new HashMap<>();
+
+    private final Map<String, Integer> displacementHits = new HashMap<>();
+    private final Map<UUID, Long> displacementCooldown = new HashMap<>();
+
+    private final Map<String, Integer> rattleHits = new HashMap<>();
+    private final Map<String, Long> rattleFirstHit = new HashMap<>();
+    private final Map<UUID, Long> rattleCooldown = new HashMap<>();
+
+    private final Map<UUID, Long> whiplashCooldown = new HashMap<>();
+
+    private final Map<UUID, Long> mischiefCooldown = new HashMap<>();
+
+    private static class OverWindow {
+        UUID attacker;
+        long expire;
+    }
+    private final Map<UUID, OverWindow> overextensionWindow = new HashMap<>();
+    private final Map<UUID, Long> overextensionCooldown = new HashMap<>();
+
+    @EventHandler
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player damager)) return;
+        if (!(event.getEntity() instanceof Player victim)) return;
+
+        ItemStack weapon = damager.getInventory().getItemInMainHand();
+        RunicWord word = RunicWordManager.getRunicWord(weapon);
+
+        // Check level requirement
+        if (word != null && damager.getLevel() < 80) {
+            event.setCancelled(true);
+            damager.sendMessage(ChatColor.RED + "You must be level 80 to use runic words.");
+            return;
+        }
+
+        // Check for overextension counter when victim strikes back
+        OverWindow win = overextensionWindow.get(damager.getUniqueId());
+        if (win != null && win.attacker.equals(victim.getUniqueId()) && System.currentTimeMillis() <= win.expire) {
+            event.setCancelled(true);
+            overextensionWindow.remove(damager.getUniqueId());
+            Vector kb = damager.getLocation().toVector().subtract(victim.getLocation().toVector()).normalize().multiply(1.5);
+            damager.setVelocity(kb);
+            return;
+        }
+
+        if (word == null) return; // no runic word
+
+        switch (word) {
+            case RUNIC_TETHER -> handleTether(damager, victim);
+            case SURGICAL_SEVER -> handleSurgicalSever(damager, victim);
+            case BLESSING_THEFT -> handleBlessingTheft(damager, victim);
+            case HUNTERS_MARK -> handleHuntersMark(damager, victim);
+            case RHYTHMIC_DISPLACEMENT -> handleDisplacement(damager, victim);
+            case CROSSHAIR_RATTLE -> handleRattle(damager, victim);
+            case WHIPLASH_SPRINT -> handleWhiplash(damager, victim);
+            case MISCHIEF -> handleMischief(damager, victim);
+            case OVEREXTENSION -> handleOverextension(damager, victim);
+        }
+    }
+
+    @EventHandler
+    public void onRegain(EntityRegainHealthEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        long until = surgicalSever.getOrDefault(player.getUniqueId(), 0L);
+        if (until > System.currentTimeMillis()) {
+            event.setAmount(event.getAmount() * 0.5);
+        }
+    }
+
+    private String key(Player a, Player b) {
+        return a.getUniqueId() + ":" + b.getUniqueId();
+    }
+
+    private void handleTether(Player damager, Player victim) {
+        String key = key(damager, victim);
+        int hits = tetherHits.getOrDefault(key, 0) + 1;
+        tetherHits.put(key, hits);
+        long now = System.currentTimeMillis();
+        if (hits >= 2) {
+            tetherHits.remove(key);
+            if (now < tetherCooldown.getOrDefault(damager.getUniqueId(), 0L)) return;
+            tetherCooldown.put(damager.getUniqueId(), now + 20000L);
+            Location anchor = damager.getLocation().clone();
+            new BukkitRunnable() {
+                final long end = System.currentTimeMillis() + 3000L;
+                @Override
+                public void run() {
+                    if (System.currentTimeMillis() >= end || victim.isDead()) { cancel(); return; }
+                    if (victim.getLocation().distanceSquared(anchor) > 49) {
+                        victim.teleport(anchor);
+                    }
+                }
+            }.runTaskTimer(plugin, 0L, 5L);
+        }
+    }
+
+    private void handleSurgicalSever(Player damager, Player victim) {
+        surgicalSever.put(victim.getUniqueId(), System.currentTimeMillis() + 3000L);
+    }
+
+    private void handleBlessingTheft(Player damager, Player victim) {
+        long now = System.currentTimeMillis();
+        if (now < blessingCooldown.getOrDefault(damager.getUniqueId(), 0L)) return;
+        List<PotionEffect> effects = new ArrayList<>();
+        for (PotionEffect eff : victim.getActivePotionEffects()) {
+            if (POSITIVE_EFFECTS.contains(eff.getType())) effects.add(eff);
+        }
+        if (effects.isEmpty()) return;
+        PotionEffect chosen = effects.get(new Random().nextInt(effects.size()));
+        victim.removePotionEffect(chosen.getType());
+        damager.addPotionEffect(new PotionEffect(chosen.getType(), 100, chosen.getAmplifier()));
+        blessingCooldown.put(damager.getUniqueId(), now + 22000L);
+    }
+
+    private void handleHuntersMark(Player damager, Player victim) {
+        long now = System.currentTimeMillis();
+        if (now < huntersCooldown.getOrDefault(damager.getUniqueId(), 0L)) return;
+        String key = key(damager, victim);
+        long first = huntersFirstHit.getOrDefault(key, 0L);
+        int hits = huntersHits.getOrDefault(key, 0);
+        if (now - first > 4000L) {
+            first = now;
+            hits = 1;
+        } else {
+            hits++;
+        }
+        huntersFirstHit.put(key, first);
+        huntersHits.put(key, hits);
+        if (hits >= 2) {
+            huntersHits.remove(key);
+            huntersFirstHit.remove(key);
+            huntersCooldown.put(damager.getUniqueId(), now + 20000L);
+            victim.removePotionEffect(PotionEffectType.INVISIBILITY);
+            victim.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 100, 0));
+        }
+    }
+
+    private void handleDisplacement(Player damager, Player victim) {
+        long now = System.currentTimeMillis();
+        if (now < displacementCooldown.getOrDefault(damager.getUniqueId(), 0L)) return;
+        String key = key(damager, victim);
+        int hits = displacementHits.getOrDefault(key, 0) + 1;
+        displacementHits.put(key, hits);
+        if (hits >= 4) {
+            displacementHits.remove(key);
+            displacementCooldown.put(damager.getUniqueId(), now + 28000L);
+            List<Integer> slots = new ArrayList<>();
+            for (int i = 0; i < 9; i++) {
+                if (victim.getInventory().getItem(i) != null) slots.add(i);
+            }
+            if (slots.isEmpty()) return;
+            int slot = slots.get(new Random().nextInt(slots.size()));
+            ItemStack original = victim.getInventory().getItem(slot);
+            ItemStack barrier = new ItemStack(Material.BARRIER);
+            ItemMeta meta = barrier.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName(ChatColor.RED + "Locked");
+                barrier.setItemMeta(meta);
+            }
+            victim.getInventory().setItem(slot, barrier);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> victim.getInventory().setItem(slot, original), 60L);
+        }
+    }
+
+    private void handleRattle(Player damager, Player victim) {
+        long now = System.currentTimeMillis();
+        if (now < rattleCooldown.getOrDefault(damager.getUniqueId(), 0L)) return;
+        String key = key(damager, victim);
+        long first = rattleFirstHit.getOrDefault(key, 0L);
+        int hits = rattleHits.getOrDefault(key, 0);
+        if (now - first > 3000L) {
+            first = now;
+            hits = 1;
+        } else {
+            hits++;
+        }
+        rattleFirstHit.put(key, first);
+        rattleHits.put(key, hits);
+        if (hits >= 2) {
+            rattleHits.remove(key);
+            rattleFirstHit.remove(key);
+            rattleCooldown.put(damager.getUniqueId(), now + 12000L);
+            victim.addPotionEffect(new PotionEffect(PotionEffectType.CONFUSION, 20, 0));
+        }
+    }
+
+    private void handleWhiplash(Player damager, Player victim) {
+        long now = System.currentTimeMillis();
+        if (!victim.isSprinting()) return;
+        if (now < whiplashCooldown.getOrDefault(damager.getUniqueId(), 0L)) return;
+        whiplashCooldown.put(damager.getUniqueId(), now + 14000L);
+        victim.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 60, 6));
+        victim.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 60, 200));
+    }
+
+    private void handleMischief(Player damager, Player victim) {
+        long now = System.currentTimeMillis();
+        if (now < mischiefCooldown.getOrDefault(damager.getUniqueId(), 0L)) return;
+        int held = victim.getInventory().getHeldItemSlot();
+        List<Integer> slots = new ArrayList<>();
+        for (int i = 0; i < 9; i++) {
+            if (i != held && victim.getInventory().getItem(i) != null) slots.add(i);
+        }
+        if (slots.isEmpty()) return;
+        int other = slots.get(new Random().nextInt(slots.size()));
+        ItemStack heldItem = victim.getInventory().getItem(held);
+        ItemStack otherItem = victim.getInventory().getItem(other);
+        victim.getInventory().setItem(held, otherItem);
+        victim.getInventory().setItem(other, heldItem);
+        mischiefCooldown.put(damager.getUniqueId(), now + 16000L);
+    }
+
+    private void handleOverextension(Player damager, Player victim) {
+        long now = System.currentTimeMillis();
+        if (now < overextensionCooldown.getOrDefault(damager.getUniqueId(), 0L)) return;
+        OverWindow win = new OverWindow();
+        win.attacker = damager.getUniqueId();
+        win.expire = now + 300L;
+        overextensionWindow.put(victim.getUniqueId(), win);
+        overextensionCooldown.put(damager.getUniqueId(), now + 16000L);
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/RunicWordManager.java
+++ b/src/main/java/com/maks/trinketsplugin/RunicWordManager.java
@@ -1,0 +1,67 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for reading and writing runic word information on items.
+ */
+public class RunicWordManager {
+    private static final String LORE_PREFIX = ChatColor.GOLD + "Runic Word: " + ChatColor.YELLOW;
+
+    /**
+     * Returns the runic word applied to the given item, or null if none.
+     */
+    public static RunicWord getRunicWord(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) {
+            return null;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (!meta.hasLore()) {
+            return null;
+        }
+        for (String line : meta.getLore()) {
+            String stripped = ChatColor.stripColor(line);
+            if (stripped.startsWith("Runic Word: ")) {
+                String name = stripped.substring("Runic Word: ".length()).trim();
+                for (RunicWord word : RunicWord.values()) {
+                    if (name.equalsIgnoreCase(word.getDisplayName())) {
+                        return word;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Adds a runic word lore line to the item.
+     */
+    public static void applyRunicWord(ItemStack item, RunicWord word) {
+        if (item == null || word == null) return;
+        ItemMeta meta = item.getItemMeta();
+        List<String> lore = meta != null && meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+        lore.add(LORE_PREFIX + word.getDisplayName());
+        if (meta != null) {
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+    }
+
+    /**
+     * Removes any runic word lore line from the item.
+     */
+    public static void removeRunicWord(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return;
+        ItemMeta meta = item.getItemMeta();
+        if (!meta.hasLore()) return;
+        List<String> lore = new ArrayList<>(meta.getLore());
+        lore.removeIf(line -> ChatColor.stripColor(line).startsWith("Runic Word:"));
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
+++ b/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
@@ -113,6 +113,8 @@ public class TrinketsPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new Q9SoulEffect(this), this);
         getServer().getPluginManager().registerEvents(new Q10SoulEffect(this), this);
         getServer().getPluginManager().registerEvents(new GemActionsListener(), this);
+        getServer().getPluginManager().registerEvents(new ConjurationListener(), this);
+        getServer().getPluginManager().registerEvents(new RunicWordEffectsListener(this), this);
         // Load data for already logged-in players
         for (Player player : Bukkit.getOnlinePlayers()) {
             getDatabaseManager().loadPlayerData(player.getUniqueId(), data -> {
@@ -137,6 +139,7 @@ public class TrinketsPlugin extends JavaPlugin {
         getCommand("soul").setExecutor(new SoulCommand());
         getCommand("jewels").setExecutor(new JewelsCommand());
         getCommand("gem_actions").setExecutor(new GemActionsCommand());
+        getCommand("conjuration_menu").setExecutor(new ConjurationCommand());
 
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -17,8 +17,13 @@ commands:
   jewels:
     description: "Show info about jewels"
     usage: /jewels
-  gem_actions:
-    description: Open gem actions GUI
-    usage: /gem_actions
-    permission: mycraftingplugin.use
-    permission-message: You do not have permission to use this command.
+    gem_actions:
+      description: Open gem actions GUI
+      usage: /gem_actions
+      permission: mycraftingplugin.use
+      permission-message: You do not have permission to use this command.
+    conjuration_menu:
+      description: Open conjuration menu
+      usage: /conjuration_menu
+      permission: mycraftingplugin.use
+      permission-message: You do not have permission to use this command.


### PR DESCRIPTION
## Summary
- introduce runic word command and menu for enchanting or dispelling weapons
- add runic word definitions, lore management, and combat effects with level requirement
- register new listeners and command in plugin startup

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable when resolving maven-resources-plugin)*


------
https://chatgpt.com/codex/tasks/task_e_68a2fdef2540832a8e4107cb04230abc