### PR TITLE
Return unused runic words to player inventory during conjuration

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/ConjurationListener.java
+++ b/src/main/java/com/maks/trinketsplugin/ConjurationListener.java
@@ -100,6 +100,14 @@ public class ConjurationListener implements Listener {
         }
         econ.withdrawPlayer(player, cost);
         RunicWordManager.applyRunicWord(weapon, word);
+
+        int leftoverAmount = wordItem.getAmount() - 1;
+        if (leftoverAmount > 0) {
+            ItemStack leftover = wordItem.clone();
+            leftover.setAmount(leftoverAmount);
+            giveItem(player, leftover);
+        }
+
         inv.setItem(11, null);
         inv.setItem(15, null);
         giveItem(player, weapon);


### PR DESCRIPTION
## Summary
- Ensure conjuration only consumes one runic word and return leftovers to the player's inventory

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a30e3341e0832a9ab3be1c6e2ddb4c