### PR TITLE
Hide attributes for conjuration menu items

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/ConjurationGUI.java
+++ b/src/main/java/com/maks/trinketsplugin/ConjurationGUI.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.ItemFlag;
 
 public class ConjurationGUI {
     public static final String TITLE_MAIN = ChatColor.DARK_PURPLE + "Conjuration";
@@ -28,6 +29,7 @@ public class ConjurationGUI {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
             meta.setDisplayName(name);
+            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
             item.setItemMeta(meta);
         }
         return item;


### PR DESCRIPTION
## Summary
- Hide default item attributes for menu items in Conjuration GUI to avoid showing attack/damage when used as menu option.

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a608bea7b8832a94d4372c57877025