### PR TITLE
Add quality augmenter command and GUI

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/AugmenterCommand.java
+++ b/src/main/java/com/maks/trinketsplugin/AugmenterCommand.java
@@ -1,0 +1,24 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class AugmenterCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (!player.hasPermission("mycraftingplugin.use")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+        AugmenterGUI.openMainMenu(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/AugmenterGUI.java
+++ b/src/main/java/com/maks/trinketsplugin/AugmenterGUI.java
@@ -1,0 +1,63 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class AugmenterGUI {
+    public static final String TITLE_MAIN = ChatColor.DARK_PURPLE + "Augmenter";
+    public static final String TITLE_APPLY = ChatColor.DARK_PURPLE + "Apply Quality";
+    public static final String TITLE_REMOVE = ChatColor.DARK_PURPLE + "Remove Quality";
+
+    private static ItemStack createFiller() {
+        ItemStack glass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta meta = glass.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            glass.setItemMeta(meta);
+        }
+        return glass;
+    }
+
+    private static ItemStack createMenuItem(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    public static void openMainMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, TITLE_MAIN);
+        ItemStack filler = createFiller();
+        for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+        inv.setItem(11, createMenuItem(Material.HONEY_BOTTLE, ChatColor.GREEN + "Apply Quality"));
+        inv.setItem(15, createMenuItem(Material.MILK_BUCKET, ChatColor.RED + "Remove Quality"));
+        player.openInventory(inv);
+    }
+
+    public static void openApplyMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, TITLE_APPLY);
+        ItemStack filler = createFiller();
+        for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+        inv.clear(11);
+        inv.clear(15);
+        inv.setItem(22, createMenuItem(Material.ANVIL, ChatColor.YELLOW + "Confirm"));
+        player.openInventory(inv);
+    }
+
+    public static void openRemoveMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, TITLE_REMOVE);
+        ItemStack filler = createFiller();
+        for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+        inv.clear(13);
+        inv.setItem(22, createMenuItem(Material.ANVIL, ChatColor.YELLOW + "Confirm (25,000,000$)"));
+        player.openInventory(inv);
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/AugmenterListener.java
+++ b/src/main/java/com/maks/trinketsplugin/AugmenterListener.java
@@ -1,0 +1,294 @@
+package com.maks.trinketsplugin;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.ChatColor;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.text.DecimalFormat;
+import java.util.*;
+
+public class AugmenterListener implements Listener {
+
+    private final DecimalFormat df = new DecimalFormat("0.0");
+
+    private void normalizeRarityLine(List<String> lore) {
+        boolean found = false;
+        for (int i = 0; i < lore.size(); ) {
+            String stripped = ChatColor.stripColor(lore.get(i)).trim().toLowerCase();
+            if (stripped.startsWith("rarity:")) {
+                if (!found) {
+                    String line = lore.get(i);
+                    int idx = line.toLowerCase().indexOf("rarity:");
+                    String suffix = line.substring(idx + "rarity:".length());
+                    if (suffix.startsWith(ChatColor.RESET.toString())) {
+                        suffix = suffix.substring(ChatColor.RESET.toString().length());
+                    }
+                    lore.set(i, ChatColor.WHITE.toString() + ChatColor.BOLD + "Rarity:" + ChatColor.RESET + suffix);
+                    found = true;
+                    i++;
+                } else {
+                    lore.remove(i);
+                }
+            } else {
+                i++;
+            }
+        }
+    }
+
+    private void giveItem(Player player, ItemStack item) {
+        if (item == null) return;
+        Map<Integer, ItemStack> left = player.getInventory().addItem(item);
+        for (ItemStack leftover : left.values()) {
+            player.getWorld().dropItem(player.getLocation(), leftover);
+        }
+    }
+
+    private boolean isAccessory(ItemStack item) {
+        if (item == null) return false;
+        for (AccessoryType type : AccessoryType.values()) {
+            if (type == AccessoryType.BOSS_SOUL) continue;
+            if (type.getMaterial() == item.getType()) return true;
+        }
+        return false;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        Player player = (Player) event.getWhoClicked();
+        Inventory top = event.getView().getTopInventory();
+        String title = event.getView().getTitle();
+
+        if (title.equals(AugmenterGUI.TITLE_MAIN)) {
+            event.setCancelled(true);
+            ItemStack clicked = event.getCurrentItem();
+            if (clicked == null) return;
+            if (clicked.getType() == Material.HONEY_BOTTLE) {
+                AugmenterGUI.openApplyMenu(player);
+            } else if (clicked.getType() == Material.MILK_BUCKET) {
+                AugmenterGUI.openRemoveMenu(player);
+            }
+        } else if (title.equals(AugmenterGUI.TITLE_APPLY)) {
+            if (event.getClickedInventory() == top) {
+                int slot = event.getSlot();
+                if (slot == 11 || slot == 15) {
+                    event.setCancelled(false);
+                } else if (slot == 22) {
+                    event.setCancelled(true);
+                    handleApplyConfirm(player, top);
+                } else {
+                    event.setCancelled(true);
+                }
+            }
+        } else if (title.equals(AugmenterGUI.TITLE_REMOVE)) {
+            if (event.getClickedInventory() == top) {
+                int slot = event.getSlot();
+                if (slot == 13) {
+                    event.setCancelled(false);
+                } else if (slot == 22) {
+                    event.setCancelled(true);
+                    handleRemoveConfirm(player, top);
+                } else {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+    private void handleApplyConfirm(Player player, Inventory inv) {
+        ItemStack item = inv.getItem(11);
+        ItemStack honey = inv.getItem(15);
+        if (item == null || honey == null) {
+            player.sendMessage(ChatColor.RED + "Place an accessory and a honey bottle.");
+            return;
+        }
+        if (!isAccessory(item)) {
+            player.sendMessage(ChatColor.RED + "Invalid accessory.");
+            return;
+        }
+        QualityHoney q = QualityHoney.fromItem(honey);
+        if (q == null) {
+            player.sendMessage(ChatColor.RED + "Invalid honey bottle.");
+            return;
+        }
+        if (honey.getAmount() > 1) {
+            ItemStack leftover = honey.clone();
+            leftover.setAmount(honey.getAmount() - 1);
+            giveItem(player, leftover);
+            honey.setAmount(1);
+        }
+        double percent = q.roll();
+        applyQuality(item, percent);
+        inv.setItem(11, null);
+        inv.setItem(15, null);
+        giveItem(player, item);
+        player.closeInventory();
+        String formatted = df.format(percent);
+        player.sendMessage(ChatColor.GREEN + "Applied quality: " + formatted + "%");
+    }
+
+    private void handleRemoveConfirm(Player player, Inventory inv) {
+        ItemStack item = inv.getItem(13);
+        if (item == null) {
+            player.sendMessage(ChatColor.RED + "Place an item.");
+            return;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        NamespacedKey percentKey = new NamespacedKey(TrinketsPlugin.getInstance(), "quality_percent");
+        if (!pdc.has(percentKey, PersistentDataType.DOUBLE)) {
+            player.sendMessage(ChatColor.RED + "This item has no quality.");
+            return;
+        }
+        Economy econ = TrinketsPlugin.getEconomy();
+        double cost = 25_000_000d;
+        if (econ.getBalance(player) < cost) {
+            player.sendMessage(ChatColor.RED + "You need $25,000,000 to remove quality.");
+            return;
+        }
+        econ.withdrawPlayer(player, cost);
+        removeQuality(item);
+        inv.setItem(13, null);
+        giveItem(player, item);
+        player.closeInventory();
+        player.sendMessage(ChatColor.GREEN + "Quality removed.");
+    }
+
+    private void applyQuality(ItemStack item, double percent) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        NamespacedKey percentKey = new NamespacedKey(TrinketsPlugin.getInstance(), "quality_percent");
+        pdc.set(percentKey, PersistentDataType.DOUBLE, percent);
+
+        // Handle attributes
+        Multimap<Attribute, AttributeModifier> existing = meta.getAttributeModifiers();
+        Multimap<Attribute, AttributeModifier> adjusted = HashMultimap.create();
+        if (existing != null) {
+            for (Attribute attr : existing.keySet()) {
+                for (AttributeModifier mod : existing.get(attr)) {
+                    NamespacedKey baseKey = new NamespacedKey(TrinketsPlugin.getInstance(), "quality_base_" + attr.name());
+                    double base = pdc.has(baseKey, PersistentDataType.DOUBLE) ?
+                            pdc.get(baseKey, PersistentDataType.DOUBLE) : mod.getAmount();
+                    pdc.set(baseKey, PersistentDataType.DOUBLE, base);
+                    double newAmount = base * (1 + percent / 100.0);
+                    AttributeModifier newMod = new AttributeModifier(mod.getUniqueId(), mod.getName(), newAmount, mod.getOperation(), mod.getSlot());
+                    adjusted.put(attr, newMod);
+                }
+            }
+        }
+        meta.setAttributeModifiers(adjusted);
+
+        // Handle lore
+        List<String> baseLore;
+        NamespacedKey loreKey = new NamespacedKey(TrinketsPlugin.getInstance(), "quality_base_lore");
+        if (pdc.has(loreKey, PersistentDataType.STRING)) {
+            baseLore = new ArrayList<>(Arrays.asList(pdc.get(loreKey, PersistentDataType.STRING).split("\\n")));
+        } else {
+            baseLore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+            pdc.set(loreKey, PersistentDataType.STRING, String.join("\n", baseLore));
+        }
+
+        List<String> newLore = new ArrayList<>();
+        ChatColor color = percent >= 0 ? ChatColor.GREEN : ChatColor.RED;
+        newLore.add(ChatColor.GRAY + "Quality: " + color + df.format(percent) + "%");
+        newLore.add("");
+        for (String line : baseLore) {
+            String stripped = ChatColor.stripColor(line);
+            double number = 0.0;
+            try {
+                java.util.regex.Matcher m = java.util.regex.Pattern.compile("(-?\\d+(?:\\.\\d+)?)").matcher(stripped);
+                if (m.find()) {
+                    number = Double.parseDouble(m.group(1));
+                    double extra = number * percent / 100.0;
+                    if (Math.abs(extra) > 0.0001) {
+                        ChatColor bonusColor = extra >= 0 ? ChatColor.GREEN : ChatColor.RED;
+                        line = line + " " + ChatColor.GOLD + "(" + bonusColor + (extra >= 0 ? "+" : "") + df.format(extra) + ChatColor.GOLD + ")";
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+            newLore.add(line);
+        }
+        normalizeRarityLine(newLore);
+        meta.setLore(newLore);
+        item.setItemMeta(meta);
+    }
+
+    private void removeQuality(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        NamespacedKey percentKey = new NamespacedKey(TrinketsPlugin.getInstance(), "quality_percent");
+        NamespacedKey loreKey = new NamespacedKey(TrinketsPlugin.getInstance(), "quality_base_lore");
+
+        // Restore attributes
+        Multimap<Attribute, AttributeModifier> restored = HashMultimap.create();
+        for (Attribute attr : Attribute.values()) {
+            NamespacedKey baseKey = new NamespacedKey(TrinketsPlugin.getInstance(), "quality_base_" + attr.name());
+            if (pdc.has(baseKey, PersistentDataType.DOUBLE)) {
+                double base = pdc.get(baseKey, PersistentDataType.DOUBLE);
+                Multimap<Attribute, AttributeModifier> current = meta.getAttributeModifiers();
+                if (current != null) {
+                    for (AttributeModifier mod : current.get(attr)) {
+                        if (mod.getName() != null) {
+                            AttributeModifier newMod = new AttributeModifier(mod.getUniqueId(), mod.getName(), base, mod.getOperation(), mod.getSlot());
+                            restored.put(attr, newMod);
+                        }
+                    }
+                }
+                pdc.remove(baseKey);
+            }
+        }
+        if (!restored.isEmpty()) meta.setAttributeModifiers(restored);
+
+        // Restore lore
+        if (pdc.has(loreKey, PersistentDataType.STRING)) {
+            String stored = pdc.get(loreKey, PersistentDataType.STRING);
+            List<String> baseLore = new ArrayList<>(Arrays.asList(stored.split("\\n")));
+            normalizeRarityLine(baseLore);
+            meta.setLore(baseLore);
+            pdc.remove(loreKey);
+        } else {
+            List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+            if (!lore.isEmpty()) {
+                lore.remove(0);
+                if (!lore.isEmpty() && lore.get(0).isEmpty()) lore.remove(0);
+            }
+            normalizeRarityLine(lore);
+            meta.setLore(lore);
+        }
+        pdc.remove(percentKey);
+        item.setItemMeta(meta);
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player)) return;
+        Player player = (Player) event.getPlayer();
+        Inventory inv = event.getInventory();
+        String title = event.getView().getTitle();
+        if (title.equals(AugmenterGUI.TITLE_APPLY)) {
+            giveItem(player, inv.getItem(11));
+            giveItem(player, inv.getItem(15));
+        } else if (title.equals(AugmenterGUI.TITLE_REMOVE)) {
+            giveItem(player, inv.getItem(13));
+        }
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/QualityHoney.java
+++ b/src/main/java/com/maks/trinketsplugin/QualityHoney.java
@@ -1,0 +1,45 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Random;
+
+public enum QualityHoney {
+    BASIC("&9[ I ] Honey Bottle", -10.0, 10.0),
+    RARE("&5[ II ] Honey Bottle", 0.0, 20.0),
+    LEGENDARY("&6[ III ] Honey Bottle", 10.0, 30.0);
+
+    private final String display;
+    private final double min;
+    private final double max;
+
+    QualityHoney(String display, double min, double max) {
+        this.display = ChatColor.translateAlternateColorCodes('&', display);
+        this.min = min;
+        this.max = max;
+    }
+
+    public double roll() {
+        return min + (new Random().nextDouble() * (max - min));
+    }
+
+    public static QualityHoney fromItem(ItemStack item) {
+        if (item == null || item.getType() != Material.HONEY_BOTTLE) return null;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) return null;
+        String name = ChatColor.stripColor(meta.getDisplayName());
+        for (QualityHoney q : values()) {
+            if (ChatColor.stripColor(q.display).equals(name)) {
+                return q;
+            }
+        }
+        return null;
+    }
+
+    public String getDisplay() {
+        return display;
+    }
+}

--- a/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
+++ b/src/main/java/com/maks/trinketsplugin/TrinketsPlugin.java
@@ -115,6 +115,7 @@ public class TrinketsPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new GemActionsListener(), this);
         getServer().getPluginManager().registerEvents(new ConjurationListener(), this);
         getServer().getPluginManager().registerEvents(new RunicWordEffectsListener(this), this);
+        getServer().getPluginManager().registerEvents(new AugmenterListener(), this);
         // Load data for already logged-in players
         for (Player player : Bukkit.getOnlinePlayers()) {
             getDatabaseManager().loadPlayerData(player.getUniqueId(), data -> {
@@ -140,6 +141,7 @@ public class TrinketsPlugin extends JavaPlugin {
         getCommand("jewels").setExecutor(new JewelsCommand());
         getCommand("gem_actions").setExecutor(new GemActionsCommand());
         getCommand("conjuration_menu").setExecutor(new ConjurationCommand());
+        getCommand("augmenter").setExecutor(new AugmenterCommand());
 
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,3 +27,8 @@ commands:
     usage: /conjuration_menu
     permission: mycraftingplugin.use
     permission-message: You do not have permission to use this command.
+  augmenter:
+    description: Open quality augmenter GUI
+    usage: /augmenter
+    permission: mycraftingplugin.use
+    permission-message: You do not have permission to use this command.


### PR DESCRIPTION
## Summary
- add /augmenter command with menu to apply or remove quality from accessories
- implement quality logic with honey bottles, lore updates, attribute scaling and removal cost
- register augmenter command, listener and plugin.yml entry

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b63f158832a9a608fedcdda7e11