### PR TITLE
Refresh hand modifiers on accessory equip/unequip

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/DatabaseManager.java
+++ b/src/main/java/com/maks/trinketsplugin/DatabaseManager.java
@@ -239,6 +239,10 @@ public class DatabaseManager {
             itemToRemove.setAmount(1);
             player.getInventory().removeItem(itemToRemove);
 
+            // Refresh main hand and offhand to clear negative modifiers
+            TrinketsPlugin.getInstance().getOffhandListener().updateMainHand(player);
+            TrinketsPlugin.getInstance().getOffhandListener().updateOffhand(player);
+
             String accessoryName = (restrictedAccessory != null) ? restrictedAccessory.getDisplayName() : type.getDisplayName();
             player.sendMessage("You have equipped the " + accessoryName + "!");
 
@@ -265,6 +269,7 @@ public class DatabaseManager {
             ItemStack accessoryToReturn = item.clone();
             accessoryToReturn.setAmount(1);
             player.getInventory().addItem(accessoryToReturn);
+            TrinketsPlugin.getInstance().getOffhandListener().updateMainHand(player);
             TrinketsPlugin.getInstance().getOffhandListener().updateOffhand(player);
 
             player.sendMessage("You have unequipped the " + type.getDisplayName() + ".");


### PR DESCRIPTION
## Summary
- Clear cached negative attribute modifiers when equipping trinket accessories
- Refresh both hands when unequipping accessories to ensure attributes update immediately

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a87226b328832a930fa4c39a3bb290