### PR TITLE
Add level requirement for augmenter

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/AugmenterCommand.java
+++ b/src/main/java/com/maks/trinketsplugin/AugmenterCommand.java
@@ -18,6 +18,10 @@ public class AugmenterCommand implements CommandExecutor {
             player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
             return true;
         }
+        if (player.getLevel() < 75) {
+            player.sendMessage(ChatColor.RED + "You must be at least level 75 to use the augmenter.");
+            return true;
+        }
         AugmenterGUI.openMainMenu(player);
         return true;
     }


### PR DESCRIPTION
## Summary
- gate augmenting behind level 75 with a clear error message

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a89afda790832aa9a701b77b83e645