### PR TITLE
Add configurable protection damage reduction curve

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/PlayerAttribStatsGUI.java
+++ b/src/main/java/com/maks/trinketsplugin/PlayerAttribStatsGUI.java
@@ -68,6 +68,18 @@ public class PlayerAttribStatsGUI {
         bsLore.add(bullet("Total: " + totalBlockStrength + "%"));
         gui.setItem(20, createItem(Material.IRON_BLOCK, ChatColor.GOLD + "Block Strength", bsLore));
 
+        ProtectionReductionCalculator.ProtectionStats protectionStats = ProtectionReductionCalculator.calculate(player);
+        List<String> protectionLore = new ArrayList<>();
+        protectionLore.add(bullet("Sum Levels: " + protectionStats.totalProtection()));
+        if (protectionStats.cappedTotalProtection() != protectionStats.totalProtection()) {
+            protectionLore.add(bullet("Capped Levels: " + protectionStats.cappedTotalProtection()));
+        }
+        protectionLore.add(bullet("Base Reduction: " + formatPercent(protectionStats.baseReductionApplied())));
+        protectionLore.add(bullet("Extra Reduction: " + formatPercent(protectionStats.extraReduction())));
+        protectionLore.add(bullet("Total Reduction: " + formatPercent(protectionStats.totalReduction())));
+        protectionLore.add(bullet("Damage Taken: " + formatPercent(protectionStats.finalDamageMultiplier())));
+        gui.setItem(21, createItem(Material.ENCHANTED_BOOK, ChatColor.BLUE + "Protection Reduction", protectionLore));
+
         // Section: Class & Skills
         gui.setItem(27, createHeader(Material.PURPLE_STAINED_GLASS_PANE, ChatColor.LIGHT_PURPLE + "Class & Skills"));
         addMyExperienceStats(gui, player, 28);

--- a/src/main/java/com/maks/trinketsplugin/PlayerDamageListener.java
+++ b/src/main/java/com/maks/trinketsplugin/PlayerDamageListener.java
@@ -1,51 +1,56 @@
 package com.maks.trinketsplugin;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.entity.Player;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class PlayerDamageListener implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerDamage(EntityDamageEvent event) {
         // Check if the entity damaged is a player
         if (!(event.getEntity() instanceof Player)) return;
 
         Player player = (Player) event.getEntity();
 
-        // Get the player's data synchronously
+        // Apply the custom protection curve first
+        double damage = event.getDamage();
+        double protectedDamage = ProtectionReductionCalculator.applyToDamage(player, damage);
+
+        // Get the player's data synchronously for block statistics
         PlayerData data = TrinketsPlugin.getInstance().getDatabaseManager().getPlayerData(player.getUniqueId());
+
+        int blockChance = 0;
+        int blockStrengthBonus = 0;
         if (data != null) {
-            int blockChance = data.getBlockChance();
-            int blockStrength = data.getBlockStrength() + 35; // Base block strength is 35%
+            blockChance = data.getBlockChance();
+            blockStrengthBonus = data.getBlockStrength();
+        }
 
-            // Add set bonus block chance from Aegis Protection - ZAKTUALIZOWANA SEKCJA
-            SetBonusManager setBonusManager = TrinketsPlugin.getInstance().getSetBonusManager();
-            if (setBonusManager != null) {
-                // Użyj metody getBlockChanceBonus zamiast ręcznego sprawdzania
-                blockChance += setBonusManager.getBlockChanceBonus(player);
-            }
+        SetBonusManager setBonusManager = TrinketsPlugin.getInstance().getSetBonusManager();
+        if (setBonusManager != null) {
+            blockChance += setBonusManager.getBlockChanceBonus(player);
+        }
 
-            // Cap block chance at 100%
-            blockChance = Math.min(blockChance, 100);
+        blockChance = Math.min(blockChance, 100);
 
-            if (blockChance > 0) {
-                // Implement the chance logic
-                Random random = new Random();
-                int rand = random.nextInt(100) + 1; // Generates a number between 1 and 100
-                if (rand <= blockChance) {
-                    // Reduce damage by blockStrength percentage
-                    double originalDamage = event.getDamage();
-                    double reducedDamage = originalDamage * (1 - (blockStrength / 100.0));
-                    event.setDamage(reducedDamage);
-
-                    // Optionally, send a message or play a sound
-                    //  player.sendMessage("You blocked the attack, reducing damage by " + blockStrength + "%!");
+        double blockMultiplier = 1.0;
+        if (blockChance > 0) {
+            int roll = ThreadLocalRandom.current().nextInt(100) + 1;
+            if (roll <= blockChance) {
+                int totalBlockStrength = 35 + blockStrengthBonus; // Base block strength is 35%
+                blockMultiplier -= totalBlockStrength / 100.0;
+                if (blockMultiplier < 0.0) {
+                    blockMultiplier = 0.0;
                 }
             }
         }
+
+        double finalDamage = protectedDamage * blockMultiplier;
+        event.setDamage(finalDamage);
     }
 }

--- a/src/main/java/com/maks/trinketsplugin/ProtectionReductionCalculator.java
+++ b/src/main/java/com/maks/trinketsplugin/ProtectionReductionCalculator.java
@@ -1,0 +1,157 @@
+package com.maks.trinketsplugin;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Objects;
+
+public final class ProtectionReductionCalculator {
+
+    private ProtectionReductionCalculator() {
+    }
+
+    public static ProtectionStats calculate(Player player) {
+        Objects.requireNonNull(player, "player");
+
+        TrinketsPlugin plugin = TrinketsPlugin.getInstance();
+        FileConfiguration config = plugin.getConfig();
+
+        int baseLevel = Math.max(0, config.getInt("protection-curve.base-level", 16));
+        double baseReduction = clamp01(config.getDouble("protection-curve.base-reduction", 0.64));
+        double maxCap = clamp01(config.getDouble("protection-curve.max-cap", 0.80));
+        int maxTotal = Math.max(0, config.getInt("protection-curve.max-total-level", 800));
+        double kFactor = Math.max(0.0, config.getDouble("protection-curve.k-factor", 0.102));
+
+        int totalProtection = Math.max(0, getTotalProtectionLevel(player));
+        int cappedTotalProtection = maxTotal > 0 ? Math.min(totalProtection, maxTotal) : totalProtection;
+
+        double perLevelReduction;
+        if (baseLevel > 0) {
+            perLevelReduction = baseReduction / baseLevel;
+        } else {
+            perLevelReduction = 0.0;
+        }
+
+        double baseReductionApplied;
+        if (baseLevel > 0) {
+            baseReductionApplied = Math.min(baseReduction, cappedTotalProtection * perLevelReduction);
+        } else {
+            baseReductionApplied = 0.0;
+        }
+
+        int extraLevels = Math.max(0, cappedTotalProtection - baseLevel);
+        double multiplier = 1.0;
+        if (extraLevels > 0 && kFactor > 0.0) {
+            multiplier = 100.0 / (100.0 + kFactor * extraLevels);
+        }
+
+        double damageMultiplierBeforeCap = (1.0 - baseReductionApplied) * multiplier;
+        double minDamageMultiplier = 1.0 - maxCap;
+        double finalDamageMultiplier = Math.max(damageMultiplierBeforeCap, minDamageMultiplier);
+
+        double totalReduction = 1.0 - finalDamageMultiplier;
+        totalReduction = Math.min(totalReduction, maxCap);
+        totalReduction = clamp01(totalReduction);
+
+        double extraReduction = Math.max(0.0, totalReduction - baseReductionApplied);
+
+        return new ProtectionStats(totalProtection, cappedTotalProtection, baseLevel, extraLevels,
+                baseReductionApplied, extraReduction, totalReduction, multiplier, finalDamageMultiplier);
+    }
+
+    public static double applyToDamage(Player player, double baseDamage) {
+        if (baseDamage <= 0.0) {
+            return 0.0;
+        }
+        ProtectionStats stats = calculate(player);
+        return Math.max(0.0, baseDamage * stats.finalDamageMultiplier());
+    }
+
+    public static int getTotalProtectionLevel(Player player) {
+        int total = 0;
+        for (ItemStack armor : player.getInventory().getArmorContents()) {
+            if (armor != null) {
+                total += armor.getEnchantmentLevel(Enchantment.PROTECTION_ENVIRONMENTAL);
+            }
+        }
+        return total;
+    }
+
+    private static double clamp01(double value) {
+        if (value < 0.0) {
+            return 0.0;
+        }
+        if (value > 1.0) {
+            return 1.0;
+        }
+        return value;
+    }
+
+    public static final class ProtectionStats {
+        private final int totalProtection;
+        private final int cappedTotalProtection;
+        private final int baseLevel;
+        private final int extraLevels;
+        private final double baseReductionApplied;
+        private final double extraReduction;
+        private final double totalReduction;
+        private final double multiplier;
+        private final double finalDamageMultiplier;
+
+        private ProtectionStats(int totalProtection, int cappedTotalProtection, int baseLevel, int extraLevels,
+                                double baseReductionApplied, double extraReduction, double totalReduction,
+                                double multiplier, double finalDamageMultiplier) {
+            this.totalProtection = totalProtection;
+            this.cappedTotalProtection = cappedTotalProtection;
+            this.baseLevel = baseLevel;
+            this.extraLevels = extraLevels;
+            this.baseReductionApplied = baseReductionApplied;
+            this.extraReduction = extraReduction;
+            this.totalReduction = totalReduction;
+            this.multiplier = multiplier;
+            this.finalDamageMultiplier = finalDamageMultiplier;
+        }
+
+        public int totalProtection() {
+            return totalProtection;
+        }
+
+        public int cappedTotalProtection() {
+            return cappedTotalProtection;
+        }
+
+        public int baseLevel() {
+            return baseLevel;
+        }
+
+        public int extraLevels() {
+            return extraLevels;
+        }
+
+        public double baseReductionApplied() {
+            return baseReductionApplied;
+        }
+
+        public double extraReduction() {
+            return extraReduction;
+        }
+
+        public double totalReduction() {
+            return totalReduction;
+        }
+
+        public double multiplier() {
+            return multiplier;
+        }
+
+        public double finalDamageMultiplier() {
+            return finalDamageMultiplier;
+        }
+
+        public double apply(double damage) {
+            return Math.max(0.0, damage * finalDamageMultiplier);
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,3 +4,10 @@ database:
   name: "minecraft_trinkets"
   user: "root"
   password: "password"
+
+protection-curve:
+  base-level: 16
+  base-reduction: 0.64
+  max-cap: 0.80
+  max-total-level: 800
+  k-factor: 0.102


### PR DESCRIPTION
## Summary
- introduce a configurable ProtectionReductionCalculator that evaluates the armour enchantment curve
- apply the new curve during player damage processing and expose the resulting stats in the attribute GUI
- extend the plugin configuration with parameters that control the reduction scaling

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e3ca416cc8832aad88d7c3ee66fe6c