### PR TITLE
Adjust damage reduction to respect vanilla cap

### DIFF
--- a/src/main/java/com/maks/trinketsplugin/ProtectionReductionCalculator.java
+++ b/src/main/java/com/maks/trinketsplugin/ProtectionReductionCalculator.java
@@ -68,7 +68,8 @@ public final class ProtectionReductionCalculator {
         ProtectionStats stats = calculate(player);
         // The Bukkit damage event already contains the vanilla protection reduction, so we
         // compensate for it here and only apply the additional scaling from the custom curve.
-        double vanillaMultiplier = 1.0 - stats.baseReductionApplied();
+        double vanillaReduction = Math.min(0.80, Math.max(0, stats.totalProtection()) * 0.04);
+        double vanillaMultiplier = 1.0 - vanillaReduction;
         if (vanillaMultiplier <= 0.0) {
             return 0.0;
         }


### PR DESCRIPTION
## Summary
- compute the vanilla protection multiplier from total protection levels, matching the 4%-per-level cap at 80%
- guard against zero-or-negative vanilla multipliers and scale custom damage reduction accordingly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3db43d18c832aa6911bef201a8ff4